### PR TITLE
feat(auth): add login use case, JWT token provider and user repository

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -1,0 +1,19 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from infrastructure.auth.token_provider import TokenProvider
+
+bearer_scheme = HTTPBearer()
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
+) -> dict:
+    token = credentials.credentials
+    try:
+        payload = TokenProvider().decode_token(token)
+        return payload  # {"sub": user_id, "email": ..., "role": ...}
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token inválido o expirado",
+        )

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from application.use_cases.login import LoginUseCase
+
+router = APIRouter(prefix="/auth", tags=["Auth"])
+
+
+class LoginRequest(BaseModel):
+    email: str
+    password: str
+
+
+@router.post("/login")
+def login(body: LoginRequest):
+    use_case = LoginUseCase()
+    try:
+        result = use_case.execute(body.email, body.password)
+        return result
+    except ValueError as e:
+        raise HTTPException(status_code=401, detail=str(e))

--- a/backend/app/application/use_cases/login.py
+++ b/backend/app/application/use_cases/login.py
@@ -1,0 +1,35 @@
+from domain.entities import User
+from infrastructure.repositories.user_repository import UserRepository
+from infrastructure.auth.password_hasher import verify_password
+from infrastructure.auth.token_provider import TokenProvider
+
+
+class LoginUseCase:
+    def __init__(self):
+        self.user_repo = UserRepository()
+        self.token_provider = TokenProvider()  # Singleton
+
+    def execute(self, email: str, password: str) -> dict:
+        user: User | None = self.user_repo.get_by_email(email)
+
+        if not user:
+            raise ValueError("Credenciales inválidas")
+
+        if not user.is_active:
+            raise ValueError("Usuario inactivo")
+
+        if not verify_password(password, user.hashed_password):
+            raise ValueError("Credenciales inválidas")
+
+        token = self.token_provider.create_token(
+            user_id=user.id,
+            email=user.email,
+            role=user.role.value,
+        )
+
+        return {
+            "access_token": token,
+            "token_type": "bearer",
+            "role": user.role.value,
+            "name": user.name,
+        }

--- a/backend/app/infrastructure/auth/password_hasher.py
+++ b/backend/app/infrastructure/auth/password_hasher.py
@@ -1,0 +1,9 @@
+from passlib.context import CryptContext
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+def hash_password(plain: str) -> str:
+    return pwd_context.hash(plain)
+
+def verify_password(plain: str, hashed: str) -> bool:
+    return pwd_context.verify(plain, hashed)

--- a/backend/app/infrastructure/auth/token_provider.py
+++ b/backend/app/infrastructure/auth/token_provider.py
@@ -1,0 +1,30 @@
+from jose import jwt, JWTError
+from datetime import datetime, timedelta
+import os
+
+
+class TokenProvider:
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance.secret = os.getenv("JWT_SECRET", "changeflow-secret-key")
+            cls._instance.algorithm = "HS256"
+            cls._instance.expire_minutes = 60
+        return cls._instance
+
+    def create_token(self, user_id: str, email: str, role: str) -> str:
+        payload = {
+            "sub": user_id,
+            "email": email,
+            "role": role,
+            "exp": datetime.utcnow() + timedelta(minutes=self.expire_minutes),
+        }
+        return jwt.encode(payload, self.secret, algorithm=self.algorithm)
+
+    def decode_token(self, token: str) -> dict:
+        try:
+            return jwt.decode(token, self.secret, algorithms=[self.algorithm])
+        except JWTError:
+            raise ValueError("Token inválido o expirado")

--- a/backend/app/infrastructure/repositories/user_repository.py
+++ b/backend/app/infrastructure/repositories/user_repository.py
@@ -1,0 +1,50 @@
+from domain.entities import User
+from domain.enums import Role
+from domain.entities import UserFactory
+import uuid
+
+
+# Simulated in-memory DB for MVP
+# Replace with real DB later
+
+_users_db: dict[str, User] = {}
+
+
+def _seed():
+    """Seed one admin user for testing."""
+    from infrastructure.auth.password_hasher import hash_password
+    admin = UserFactory.create(
+        id=str(uuid.uuid4()),
+        name="Admin",
+        email="admin@changeflow.com",
+        hashed_password=hash_password("admin1234"),
+        role=Role.ADMIN,
+    )
+    _users_db[admin.email] = admin
+
+_seed()
+
+
+class UserRepository:
+    def get_by_email(self, email: str) -> User | None:
+        return _users_db.get(email)
+
+    def get_by_id(self, user_id: str) -> User | None:
+        for user in _users_db.values():
+            if user.id == user_id:
+                return user
+        return None
+
+    def save(self, user: User) -> User:
+        _users_db[user.email] = user
+        return user
+
+    def get_all(self) -> list[User]:
+        return list(_users_db.values())
+
+    def delete(self, user_id: str) -> bool:
+        for email, user in _users_db.items():
+            if user.id == user_id:
+                del _users_db[email]
+                return True
+        return False

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,5 @@ psycopg2-binary
 alembic
 pydantic
 python-dotenv
+python-jose[cryptography]
+passlib[bcrypt]


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa el flujo completo de login con JWT.

## Archivos
- `infrastructure/repositories/user_repository.py` — repositorio en memoria
- `infrastructure/auth/password_hasher.py` — hash y verificación bcrypt
- `infrastructure/auth/token_provider.py` — Singleton para crear/decodificar JWT
- `application/use_cases/login.py` — lógica de login
- `api/routes/auth.py` — endpoint POST /auth/login
- `api/dependencies.py` — dependencia get_current_user para proteger rutas

## Notas
- TokenProvider es Singleton: una sola instancia maneja todos los tokens
- Seed de usuario admin incluido en el repositorio para pruebas
- Contraseña de prueba: admin@changeflow.com / admin1234

Closes #18 