### PR TITLE
feat(users): add register user use case and CRUD endpoints (Admin only)

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -17,3 +17,18 @@ def get_current_user(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Token inválido o expirado",
         )
+
+from domain.enums import Role
+from functools import lru_cache
+
+
+def require_role(*allowed_roles: Role):
+    def dependency(current_user: dict = Depends(get_current_user)):
+        user_role = current_user.get("role")
+        if user_role not in [r.value for r in allowed_roles]:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="No tienes permisos para realizar esta acción",
+            )
+        return current_user
+    return dependency

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -1,0 +1,19 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from infrastructure.auth.token_provider import TokenProvider
+
+bearer_scheme = HTTPBearer()
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
+) -> dict:
+    token = credentials.credentials
+    try:
+        payload = TokenProvider().decode_token(token)
+        return payload  # {"sub": user_id, "email": ..., "role": ...}
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token inválido o expirado",
+        )

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from application.use_cases.login import LoginUseCase
+
+router = APIRouter(prefix="/auth", tags=["Auth"])
+
+
+class LoginRequest(BaseModel):
+    email: str
+    password: str
+
+
+@router.post("/login")
+def login(body: LoginRequest):
+    use_case = LoginUseCase()
+    try:
+        result = use_case.execute(body.email, body.password)
+        return result
+    except ValueError as e:
+        raise HTTPException(status_code=401, detail=str(e))

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -1,0 +1,100 @@
+from fastapi import APIRouter, HTTPException, Depends
+from pydantic import BaseModel
+from domain.enums import Role
+from application.use_cases.register_user import RegisterUserUseCase
+from infrastructure.repositories.user_repository import UserRepository
+from api.dependencies import get_current_user, require_role
+
+router = APIRouter(prefix="/users", tags=["Users"])
+
+
+# --- Schemas ---
+
+class CreateUserRequest(BaseModel):
+    name: str
+    email: str
+    password: str
+    role: Role
+
+
+class UpdateUserRequest(BaseModel):
+    name: str | None = None
+    is_active: bool | None = None
+
+
+# --- Endpoints ---
+
+@router.get("/")
+def get_all_users(current_user: dict = Depends(require_role(Role.ADMIN))):
+    repo = UserRepository()
+    users = repo.get_all()
+    return [
+        {
+            "id": u.id,
+            "name": u.name,
+            "email": u.email,
+            "role": u.role.value,
+            "is_active": u.is_active,
+        }
+        for u in users
+    ]
+
+
+@router.post("/", status_code=201)
+def create_user(
+    body: CreateUserRequest,
+    current_user: dict = Depends(require_role(Role.ADMIN)),
+):
+    use_case = RegisterUserUseCase()
+    try:
+        user = use_case.execute(
+            name=body.name,
+            email=body.email,
+            password=body.password,
+            role=body.role,
+        )
+        return {
+            "id": user.id,
+            "name": user.name,
+            "email": user.email,
+            "role": user.role.value,
+        }
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.put("/{user_id}")
+def update_user(
+    user_id: str,
+    body: UpdateUserRequest,
+    current_user: dict = Depends(require_role(Role.ADMIN)),
+):
+    repo = UserRepository()
+    user = repo.get_by_id(user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="Usuario no encontrado")
+
+    if body.name is not None:
+        user.name = body.name
+    if body.is_active is not None:
+        user.is_active = body.is_active
+
+    repo.save(user)
+    return {
+        "id": user.id,
+        "name": user.name,
+        "email": user.email,
+        "role": user.role.value,
+        "is_active": user.is_active,
+    }
+
+
+@router.delete("/{user_id}", status_code=204)
+def delete_user(
+    user_id: str,
+    current_user: dict = Depends(require_role(Role.ADMIN)),
+):
+    repo = UserRepository()
+    deleted = repo.delete(user_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Usuario no encontrado")

--- a/backend/app/application/use_cases/login.py
+++ b/backend/app/application/use_cases/login.py
@@ -1,0 +1,35 @@
+from domain.entities import User
+from infrastructure.repositories.user_repository import UserRepository
+from infrastructure.auth.password_hasher import verify_password
+from infrastructure.auth.token_provider import TokenProvider
+
+
+class LoginUseCase:
+    def __init__(self):
+        self.user_repo = UserRepository()
+        self.token_provider = TokenProvider()  # Singleton
+
+    def execute(self, email: str, password: str) -> dict:
+        user: User | None = self.user_repo.get_by_email(email)
+
+        if not user:
+            raise ValueError("Credenciales inválidas")
+
+        if not user.is_active:
+            raise ValueError("Usuario inactivo")
+
+        if not verify_password(password, user.hashed_password):
+            raise ValueError("Credenciales inválidas")
+
+        token = self.token_provider.create_token(
+            user_id=user.id,
+            email=user.email,
+            role=user.role.value,
+        )
+
+        return {
+            "access_token": token,
+            "token_type": "bearer",
+            "role": user.role.value,
+            "name": user.name,
+        }

--- a/backend/app/application/use_cases/register_user.py
+++ b/backend/app/application/use_cases/register_user.py
@@ -1,0 +1,25 @@
+import uuid
+from domain.entities import UserFactory
+from domain.enums import Role
+from infrastructure.repositories.user_repository import UserRepository
+from infrastructure.auth.password_hasher import hash_password
+
+
+class RegisterUserUseCase:
+    def __init__(self):
+        self.user_repo = UserRepository()
+
+    def execute(self, name: str, email: str, password: str, role: Role):
+        existing = self.user_repo.get_by_email(email)
+        if existing:
+            raise ValueError(f"Ya existe un usuario con el email {email}")
+
+        user = UserFactory.create(
+            id=str(uuid.uuid4()),
+            name=name,
+            email=email,
+            hashed_password=hash_password(password),
+            role=role,
+        )
+
+        return self.user_repo.save(user)

--- a/backend/app/infrastructure/auth/password_hasher.py
+++ b/backend/app/infrastructure/auth/password_hasher.py
@@ -1,0 +1,9 @@
+from passlib.context import CryptContext
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+def hash_password(plain: str) -> str:
+    return pwd_context.hash(plain)
+
+def verify_password(plain: str, hashed: str) -> bool:
+    return pwd_context.verify(plain, hashed)

--- a/backend/app/infrastructure/auth/token_provider.py
+++ b/backend/app/infrastructure/auth/token_provider.py
@@ -1,0 +1,30 @@
+from jose import jwt, JWTError
+from datetime import datetime, timedelta
+import os
+
+
+class TokenProvider:
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance.secret = os.getenv("JWT_SECRET", "changeflow-secret-key")
+            cls._instance.algorithm = "HS256"
+            cls._instance.expire_minutes = 60
+        return cls._instance
+
+    def create_token(self, user_id: str, email: str, role: str) -> str:
+        payload = {
+            "sub": user_id,
+            "email": email,
+            "role": role,
+            "exp": datetime.utcnow() + timedelta(minutes=self.expire_minutes),
+        }
+        return jwt.encode(payload, self.secret, algorithm=self.algorithm)
+
+    def decode_token(self, token: str) -> dict:
+        try:
+            return jwt.decode(token, self.secret, algorithms=[self.algorithm])
+        except JWTError:
+            raise ValueError("Token inválido o expirado")

--- a/backend/app/infrastructure/repositories/user_repository.py
+++ b/backend/app/infrastructure/repositories/user_repository.py
@@ -1,0 +1,50 @@
+from domain.entities import User
+from domain.enums import Role
+from domain.entities import UserFactory
+import uuid
+
+
+# Simulated in-memory DB for MVP
+# Replace with real DB later
+
+_users_db: dict[str, User] = {}
+
+
+def _seed():
+    """Seed one admin user for testing."""
+    from infrastructure.auth.password_hasher import hash_password
+    admin = UserFactory.create(
+        id=str(uuid.uuid4()),
+        name="Admin",
+        email="admin@changeflow.com",
+        hashed_password=hash_password("admin1234"),
+        role=Role.ADMIN,
+    )
+    _users_db[admin.email] = admin
+
+_seed()
+
+
+class UserRepository:
+    def get_by_email(self, email: str) -> User | None:
+        return _users_db.get(email)
+
+    def get_by_id(self, user_id: str) -> User | None:
+        for user in _users_db.values():
+            if user.id == user_id:
+                return user
+        return None
+
+    def save(self, user: User) -> User:
+        _users_db[user.email] = user
+        return user
+
+    def get_all(self) -> list[User]:
+        return list(_users_db.values())
+
+    def delete(self, user_id: str) -> bool:
+        for email, user in _users_db.items():
+            if user.id == user_id:
+                del _users_db[email]
+                return True
+        return False

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,5 @@ psycopg2-binary
 alembic
 pydantic
 python-dotenv
+python-jose[cryptography]
+passlib[bcrypt]


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa el CRUD completo de usuarios, accesible únicamente para el rol ADMIN.

## Archivos
- `application/use_cases/register_user.py` — lógica para registrar usuario con hash de password
- `api/routes/users.py` — endpoints GET, POST, PUT, DELETE /users
- `api/dependencies.py` — se agrega require_role() para proteger por rol

## Endpoints
- GET    /users        → lista todos los usuarios
- POST   /users        → crea un nuevo usuario
- PUT    /users/{id}   → edita nombre o estado activo
- DELETE /users/{id}   → elimina un usuario

## Notas
- Todos los endpoints requieren rol ADMIN
- Retorna 403 si otro rol intenta acceder
- Retorna 400 si el email ya está registrado

Closes #19 