### PR TITLE
feat(frontend): add login and users admin pages in Streamlit

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -17,3 +17,18 @@ def get_current_user(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Token inválido o expirado",
         )
+
+from domain.enums import Role
+from functools import lru_cache
+
+
+def require_role(*allowed_roles: Role):
+    def dependency(current_user: dict = Depends(get_current_user)):
+        user_role = current_user.get("role")
+        if user_role not in [r.value for r in allowed_roles]:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="No tienes permisos para realizar esta acción",
+            )
+        return current_user
+    return dependency

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -1,6 +1,8 @@
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from infrastructure.auth.token_provider import TokenProvider
+from domain.enums import Role
+
 
 bearer_scheme = HTTPBearer()
 
@@ -17,9 +19,6 @@ def get_current_user(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Token inválido o expirado",
         )
-
-from domain.enums import Role
-from functools import lru_cache
 
 
 def require_role(*allowed_roles: Role):

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -1,0 +1,19 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from infrastructure.auth.token_provider import TokenProvider
+
+bearer_scheme = HTTPBearer()
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
+) -> dict:
+    token = credentials.credentials
+    try:
+        payload = TokenProvider().decode_token(token)
+        return payload  # {"sub": user_id, "email": ..., "role": ...}
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token inválido o expirado",
+        )

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from application.use_cases.login import LoginUseCase
+
+router = APIRouter(prefix="/auth", tags=["Auth"])
+
+
+class LoginRequest(BaseModel):
+    email: str
+    password: str
+
+
+@router.post("/login")
+def login(body: LoginRequest):
+    use_case = LoginUseCase()
+    try:
+        result = use_case.execute(body.email, body.password)
+        return result
+    except ValueError as e:
+        raise HTTPException(status_code=401, detail=str(e))

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -98,3 +98,32 @@ def delete_user(
     deleted = repo.delete(user_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Usuario no encontrado")
+    
+
+from application.use_cases.assign_role import AssignRoleUseCase
+
+class AssignRoleRequest(BaseModel):
+    role: Role
+
+
+@router.put("/{user_id}/role")
+def assign_role(
+    user_id: str,
+    body: AssignRoleRequest,
+    current_user: dict = Depends(require_role(Role.ADMIN)),
+):
+    use_case = AssignRoleUseCase()
+    try:
+        user = use_case.execute(user_id=user_id, new_role=body.role)
+        return {
+            "id": user.id,
+            "name": user.name,
+            "email": user.email,
+            "role": user.role.value,
+            "permissions": [p.value for p in user.permissions],
+        }
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    
+
+    

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -1,0 +1,100 @@
+from fastapi import APIRouter, HTTPException, Depends
+from pydantic import BaseModel
+from domain.enums import Role
+from application.use_cases.register_user import RegisterUserUseCase
+from infrastructure.repositories.user_repository import UserRepository
+from api.dependencies import get_current_user, require_role
+
+router = APIRouter(prefix="/users", tags=["Users"])
+
+
+# --- Schemas ---
+
+class CreateUserRequest(BaseModel):
+    name: str
+    email: str
+    password: str
+    role: Role
+
+
+class UpdateUserRequest(BaseModel):
+    name: str | None = None
+    is_active: bool | None = None
+
+
+# --- Endpoints ---
+
+@router.get("/")
+def get_all_users(current_user: dict = Depends(require_role(Role.ADMIN))):
+    repo = UserRepository()
+    users = repo.get_all()
+    return [
+        {
+            "id": u.id,
+            "name": u.name,
+            "email": u.email,
+            "role": u.role.value,
+            "is_active": u.is_active,
+        }
+        for u in users
+    ]
+
+
+@router.post("/", status_code=201)
+def create_user(
+    body: CreateUserRequest,
+    current_user: dict = Depends(require_role(Role.ADMIN)),
+):
+    use_case = RegisterUserUseCase()
+    try:
+        user = use_case.execute(
+            name=body.name,
+            email=body.email,
+            password=body.password,
+            role=body.role,
+        )
+        return {
+            "id": user.id,
+            "name": user.name,
+            "email": user.email,
+            "role": user.role.value,
+        }
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.put("/{user_id}")
+def update_user(
+    user_id: str,
+    body: UpdateUserRequest,
+    current_user: dict = Depends(require_role(Role.ADMIN)),
+):
+    repo = UserRepository()
+    user = repo.get_by_id(user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="Usuario no encontrado")
+
+    if body.name is not None:
+        user.name = body.name
+    if body.is_active is not None:
+        user.is_active = body.is_active
+
+    repo.save(user)
+    return {
+        "id": user.id,
+        "name": user.name,
+        "email": user.email,
+        "role": user.role.value,
+        "is_active": user.is_active,
+    }
+
+
+@router.delete("/{user_id}", status_code=204)
+def delete_user(
+    user_id: str,
+    current_user: dict = Depends(require_role(Role.ADMIN)),
+):
+    repo = UserRepository()
+    deleted = repo.delete(user_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Usuario no encontrado")

--- a/backend/app/application/use_cases/assign_role.py
+++ b/backend/app/application/use_cases/assign_role.py
@@ -1,0 +1,20 @@
+from domain.enums import Role, Permission
+from domain.value_objects import ROLE_PERMISSIONS
+from infrastructure.repositories.user_repository import UserRepository
+
+
+class AssignRoleUseCase:
+    def __init__(self):
+        self.user_repo = UserRepository()
+
+    def execute(self, user_id: str, new_role: Role):
+        user = self.user_repo.get_by_id(user_id)
+
+        if not user:
+            raise ValueError("Usuario no encontrado")
+
+        user.role = new_role
+        user.permissions = ROLE_PERMISSIONS.get(new_role, [])
+
+        self.user_repo.save(user)
+        return user

--- a/backend/app/application/use_cases/login.py
+++ b/backend/app/application/use_cases/login.py
@@ -1,0 +1,35 @@
+from domain.entities import User
+from infrastructure.repositories.user_repository import UserRepository
+from infrastructure.auth.password_hasher import verify_password
+from infrastructure.auth.token_provider import TokenProvider
+
+
+class LoginUseCase:
+    def __init__(self):
+        self.user_repo = UserRepository()
+        self.token_provider = TokenProvider()  # Singleton
+
+    def execute(self, email: str, password: str) -> dict:
+        user: User | None = self.user_repo.get_by_email(email)
+
+        if not user:
+            raise ValueError("Credenciales inválidas")
+
+        if not user.is_active:
+            raise ValueError("Usuario inactivo")
+
+        if not verify_password(password, user.hashed_password):
+            raise ValueError("Credenciales inválidas")
+
+        token = self.token_provider.create_token(
+            user_id=user.id,
+            email=user.email,
+            role=user.role.value,
+        )
+
+        return {
+            "access_token": token,
+            "token_type": "bearer",
+            "role": user.role.value,
+            "name": user.name,
+        }

--- a/backend/app/application/use_cases/register_user.py
+++ b/backend/app/application/use_cases/register_user.py
@@ -1,0 +1,25 @@
+import uuid
+from domain.entities import UserFactory
+from domain.enums import Role
+from infrastructure.repositories.user_repository import UserRepository
+from infrastructure.auth.password_hasher import hash_password
+
+
+class RegisterUserUseCase:
+    def __init__(self):
+        self.user_repo = UserRepository()
+
+    def execute(self, name: str, email: str, password: str, role: Role):
+        existing = self.user_repo.get_by_email(email)
+        if existing:
+            raise ValueError(f"Ya existe un usuario con el email {email}")
+
+        user = UserFactory.create(
+            id=str(uuid.uuid4()),
+            name=name,
+            email=email,
+            hashed_password=hash_password(password),
+            role=role,
+        )
+
+        return self.user_repo.save(user)

--- a/backend/app/infrastructure/auth/password_hasher.py
+++ b/backend/app/infrastructure/auth/password_hasher.py
@@ -1,0 +1,9 @@
+from passlib.context import CryptContext
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+def hash_password(plain: str) -> str:
+    return pwd_context.hash(plain)
+
+def verify_password(plain: str, hashed: str) -> bool:
+    return pwd_context.verify(plain, hashed)

--- a/backend/app/infrastructure/auth/token_provider.py
+++ b/backend/app/infrastructure/auth/token_provider.py
@@ -1,0 +1,30 @@
+from jose import jwt, JWTError
+from datetime import datetime, timedelta
+import os
+
+
+class TokenProvider:
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance.secret = os.getenv("JWT_SECRET", "changeflow-secret-key")
+            cls._instance.algorithm = "HS256"
+            cls._instance.expire_minutes = 60
+        return cls._instance
+
+    def create_token(self, user_id: str, email: str, role: str) -> str:
+        payload = {
+            "sub": user_id,
+            "email": email,
+            "role": role,
+            "exp": datetime.utcnow() + timedelta(minutes=self.expire_minutes),
+        }
+        return jwt.encode(payload, self.secret, algorithm=self.algorithm)
+
+    def decode_token(self, token: str) -> dict:
+        try:
+            return jwt.decode(token, self.secret, algorithms=[self.algorithm])
+        except JWTError:
+            raise ValueError("Token inválido o expirado")

--- a/backend/app/infrastructure/repositories/user_repository.py
+++ b/backend/app/infrastructure/repositories/user_repository.py
@@ -1,0 +1,50 @@
+from domain.entities import User
+from domain.enums import Role
+from domain.entities import UserFactory
+import uuid
+
+
+# Simulated in-memory DB for MVP
+# Replace with real DB later
+
+_users_db: dict[str, User] = {}
+
+
+def _seed():
+    """Seed one admin user for testing."""
+    from infrastructure.auth.password_hasher import hash_password
+    admin = UserFactory.create(
+        id=str(uuid.uuid4()),
+        name="Admin",
+        email="admin@changeflow.com",
+        hashed_password=hash_password("admin1234"),
+        role=Role.ADMIN,
+    )
+    _users_db[admin.email] = admin
+
+_seed()
+
+
+class UserRepository:
+    def get_by_email(self, email: str) -> User | None:
+        return _users_db.get(email)
+
+    def get_by_id(self, user_id: str) -> User | None:
+        for user in _users_db.values():
+            if user.id == user_id:
+                return user
+        return None
+
+    def save(self, user: User) -> User:
+        _users_db[user.email] = user
+        return user
+
+    def get_all(self) -> list[User]:
+        return list(_users_db.values())
+
+    def delete(self, user_id: str) -> bool:
+        for email, user in _users_db.items():
+            if user.id == user_id:
+                del _users_db[email]
+                return True
+        return False

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,5 @@ psycopg2-binary
 alembic
 pydantic
 python-dotenv
+python-jose[cryptography]
+passlib[bcrypt]

--- a/frontend/app/main.py
+++ b/frontend/app/main.py
@@ -1,0 +1,20 @@
+import streamlit as st
+
+st.set_page_config(
+    page_title="ChangeFlow",
+    page_icon="🔄",
+    layout="wide",
+)
+
+if "token" not in st.session_state:
+    st.session_state.token = None
+if "user" not in st.session_state:
+    st.session_state.user = None
+
+st.title("🔄 ChangeFlow")
+st.markdown("Plataforma de solicitudes de cambios técnicos.")
+
+if st.session_state.user:
+    st.success(f"Bienvenido, **{st.session_state.user['name']}** — Rol: `{st.session_state.user['role']}`")
+else:
+    st.info("Por favor inicia sesión desde el menú lateral.")

--- a/frontend/app/pages/login.py
+++ b/frontend/app/pages/login.py
@@ -1,0 +1,42 @@
+import streamlit as st
+import requests
+
+API_URL = "http://localhost:8000"
+
+st.set_page_config(page_title="Login — ChangeFlow", page_icon="🔐")
+st.title("🔐 Iniciar sesión")
+
+if st.session_state.get("token"):
+    st.success(f"Ya estás autenticado como **{st.session_state.user['name']}**")
+    if st.button("Cerrar sesión"):
+        st.session_state.token = None
+        st.session_state.user = None
+        st.rerun()
+else:
+    with st.form("login_form"):
+        email = st.text_input("Email")
+        password = st.text_input("Contraseña", type="password")
+        submitted = st.form_submit_button("Ingresar")
+
+    if submitted:
+        if not email or not password:
+            st.error("Completa todos los campos.")
+        else:
+            try:
+                response = requests.post(
+                    f"{API_URL}/auth/login",
+                    json={"email": email, "password": password},
+                )
+                if response.status_code == 200:
+                    data = response.json()
+                    st.session_state.token = data["access_token"]
+                    st.session_state.user = {
+                        "name": data["name"],
+                        "role": data["role"],
+                    }
+                    st.success(f"Bienvenido, {data['name']}!")
+                    st.rerun()
+                else:
+                    st.error("Credenciales incorrectas. Intenta de nuevo.")
+            except requests.exceptions.ConnectionError:
+                st.error("No se pudo conectar con el servidor. Verifica que la API esté corriendo.")

--- a/frontend/app/pages/users_admin.py
+++ b/frontend/app/pages/users_admin.py
@@ -1,0 +1,97 @@
+import streamlit as st
+import requests
+
+API_URL = "http://localhost:8000"
+
+st.set_page_config(page_title="Administración de usuarios — ChangeFlow", page_icon="👥")
+st.title("👥 Administración de usuarios")
+
+# --- Guard: solo Admin ---
+if not st.session_state.get("token"):
+    st.warning("Debes iniciar sesión para acceder a esta página.")
+    st.stop()
+
+if st.session_state.user.get("role") != "ADMIN":
+    st.error("No tienes permisos para acceder a esta sección.")
+    st.stop()
+
+headers = {"Authorization": f"Bearer {st.session_state.token}"}
+
+
+# --- Listar usuarios ---
+st.subheader("Usuarios registrados")
+
+response = requests.get(f"{API_URL}/users/", headers=headers)
+
+if response.status_code == 200:
+    users = response.json()
+    if users:
+        st.table([
+            {
+                "Nombre": u["name"],
+                "Email": u["email"],
+                "Rol": u["role"],
+                "Activo": "✅" if u["is_active"] else "❌",
+            }
+            for u in users
+        ])
+    else:
+        st.info("No hay usuarios registrados.")
+else:
+    st.error("Error al cargar usuarios.")
+
+
+# --- Crear usuario ---
+st.divider()
+st.subheader("Crear nuevo usuario")
+
+with st.form("create_user_form"):
+    name = st.text_input("Nombre")
+    email = st.text_input("Email")
+    password = st.text_input("Contraseña", type="password")
+    role = st.selectbox("Rol", ["ENGINEER", "TECH_LEAD", "OPS_REVIEWER", "SECURITY_REVIEWER", "ADMIN"])
+    submitted = st.form_submit_button("Crear usuario")
+
+if submitted:
+    if not name or not email or not password:
+        st.error("Completa todos los campos.")
+    else:
+        res = requests.post(
+            f"{API_URL}/users/",
+            json={"name": name, "email": email, "password": password, "role": role},
+            headers=headers,
+        )
+        if res.status_code == 201:
+            st.success(f"Usuario {name} creado correctamente.")
+            st.rerun()
+        elif res.status_code == 400:
+            st.error(res.json().get("detail", "Error al crear usuario."))
+        else:
+            st.error("Error inesperado.")
+
+
+# --- Asignar rol ---
+st.divider()
+st.subheader("Cambiar rol de usuario")
+
+with st.form("assign_role_form"):
+    user_id = st.text_input("ID del usuario")
+    new_role = st.selectbox("Nuevo rol", ["ENGINEER", "TECH_LEAD", "OPS_REVIEWER", "SECURITY_REVIEWER", "ADMIN"])
+    submitted_role = st.form_submit_button("Asignar rol")
+
+if submitted_role:
+    if not user_id:
+        st.error("Ingresa el ID del usuario.")
+    else:
+        res = requests.put(
+            f"{API_URL}/users/{user_id}/role",
+            json={"role": new_role},
+            headers=headers,
+        )
+        if res.status_code == 200:
+            st.success(f"Rol actualizado correctamente.")
+            st.rerun()
+        elif res.status_code == 404:
+            st.error("Usuario no encontrado.")
+        else:
+            st.error("Error inesperado.")


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega las vistas de frontend en Streamlit para login y administración de usuarios.

## Archivos
- `frontend/app/main.py` — página principal con estado de sesión
- `frontend/app/pages/login.py` — formulario de login, guarda token en session_state
- `frontend/app/pages/users_admin.py` — CRUD visual de usuarios, solo accesible para ADMIN

## Flujo
1. Usuario entra a login.py e ingresa sus credenciales
2. Si son válidas, el token y datos del usuario se guardan en session_state
3. El Admin puede acceder a users_admin.py para ver, crear y cambiar roles
4. Cualquier rol distinto a ADMIN ve un mensaje de error y no puede operar

## Notas
- Guard en users_admin.py: corta si no hay token o si el rol no es ADMIN
- Token se envía como Bearer en cada request a la API
- La API debe estar corriendo en localhost:8000

Closes #21 