### PR TITLE
feat(domain): add Approval and Decision entities

### DIFF
--- a/backend/app/domain/entities.py
+++ b/backend/app/domain/entities.py
@@ -1,0 +1,60 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional
+from uuid import UUID, uuid4
+
+from app.domain.enums import ApprovalStatus, DecisionAction
+
+
+@dataclass
+class Approval:
+    """
+    Representa una aprobación asignada a un reviewer para una solicitud de cambio.
+    Una solicitud puede tener múltiples Approvals (ej: cambios HIGH risk requieren 2).
+    """
+    request_id: UUID
+    reviewer_id: UUID
+    id: UUID = field(default_factory=uuid4)
+    status: ApprovalStatus = ApprovalStatus.PENDING
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    decided_at: Optional[datetime] = None
+
+    def is_pending(self) -> bool:
+        return self.status == ApprovalStatus.PENDING
+
+    def mark_approved(self) -> None:
+        if not self.is_pending():
+            raise ValueError(
+                f"No se puede aprobar una Approval con estado {self.status.value}"
+            )
+        self.status = ApprovalStatus.APPROVED
+        self.decided_at = datetime.utcnow()
+
+    def mark_rejected(self) -> None:
+        if not self.is_pending():
+            raise ValueError(
+                f"No se puede rechazar una Approval con estado {self.status.value}"
+            )
+        self.status = ApprovalStatus.REJECTED
+        self.decided_at = datetime.utcnow()
+
+
+@dataclass
+class Decision:
+    """
+    Representa la decisión concreta tomada por un reviewer sobre una Approval.
+    Guarda el detalle de la acción y el comentario asociado.
+    """
+    approval_id: UUID
+    action: DecisionAction
+    id: UUID = field(default_factory=uuid4)
+    comment: Optional[str] = None
+    decided_at: datetime = field(default_factory=datetime.utcnow)
+
+    def __post_init__(self):
+        # Regla de negocio: rechazar o pedir cambios requiere comentario
+        if self.action in (DecisionAction.REJECT, DecisionAction.REQUEST_CHANGES):
+            if not self.comment or not self.comment.strip():
+                raise ValueError(
+                    f"La acción {self.action.value} requiere un comentario."
+                )

--- a/backend/app/domain/enums.py
+++ b/backend/app/domain/enums.py
@@ -1,0 +1,33 @@
+from enum import Enum
+
+
+class RiskLevel(str, Enum):
+    """Nivel de riesgo de un cambio técnico en ChangeFlow."""
+    LOW = "LOW"
+    MEDIUM = "MEDIUM"
+    HIGH = "HIGH"
+
+
+class RequestStatus(str, Enum):
+    """Estados del ciclo de vida de una solicitud de cambio."""
+    DRAFT = "DRAFT"
+    SUBMITTED = "SUBMITTED"
+    IN_REVIEW = "IN_REVIEW"
+    APPROVED = "APPROVED"
+    REJECTED = "REJECTED"
+    CHANGES_REQUESTED = "CHANGES_REQUESTED"
+    COMPLETED = "COMPLETED"
+
+
+class ApprovalStatus(str, Enum):
+    """Estado de una aprobación individual dentro de una solicitud."""
+    PENDING = "PENDING"
+    APPROVED = "APPROVED"
+    REJECTED = "REJECTED"
+
+
+class DecisionAction(str, Enum):
+    """Acción tomada por un aprobador."""
+    APPROVE = "APPROVE"
+    REJECT = "REJECT"
+    REQUEST_CHANGES = "REQUEST_CHANGES"

--- a/backend/app/tests/test_entities.py
+++ b/backend/app/tests/test_entities.py
@@ -1,0 +1,57 @@
+import pytest
+from uuid import uuid4
+
+from app.domain.entities import Approval, Decision
+from app.domain.enums import ApprovalStatus, DecisionAction
+
+
+class TestApproval:
+    def test_approval_starts_pending(self):
+        approval = Approval(request_id=uuid4(), reviewer_id=uuid4())
+        assert approval.status == ApprovalStatus.PENDING
+        assert approval.is_pending()
+        assert approval.decided_at is None
+
+    def test_mark_approved_changes_status(self):
+        approval = Approval(request_id=uuid4(), reviewer_id=uuid4())
+        approval.mark_approved()
+        assert approval.status == ApprovalStatus.APPROVED
+        assert approval.decided_at is not None
+
+    def test_cannot_approve_twice(self):
+        approval = Approval(request_id=uuid4(), reviewer_id=uuid4())
+        approval.mark_approved()
+        with pytest.raises(ValueError):
+            approval.mark_approved()
+
+    def test_cannot_reject_already_approved(self):
+        approval = Approval(request_id=uuid4(), reviewer_id=uuid4())
+        approval.mark_approved()
+        with pytest.raises(ValueError):
+            approval.mark_rejected()
+
+
+class TestDecision:
+    def test_approve_decision_does_not_require_comment(self):
+        decision = Decision(approval_id=uuid4(), action=DecisionAction.APPROVE)
+        assert decision.action == DecisionAction.APPROVE
+
+    def test_reject_decision_requires_comment(self):
+        with pytest.raises(ValueError):
+            Decision(approval_id=uuid4(), action=DecisionAction.REJECT)
+
+    def test_request_changes_requires_comment(self):
+        with pytest.raises(ValueError):
+            Decision(
+                approval_id=uuid4(),
+                action=DecisionAction.REQUEST_CHANGES,
+                comment="   "  # solo espacios tampoco vale
+            )
+
+    def test_reject_with_valid_comment_works(self):
+        decision = Decision(
+            approval_id=uuid4(),
+            action=DecisionAction.REJECT,
+            comment="Falta plan de rollback"
+        )
+        assert decision.comment == "Falta plan de rollback"


### PR DESCRIPTION
## Descripción
Implementa las entidades de dominio Approval y Decision para el feature 
de aprobación de solicitudes de cambio en ChangeFlow.

## Cambios
- Nuevo archivo `domain/enums.py` con RiskLevel, RequestStatus, ApprovalStatus, DecisionAction
- Nuevo archivo `domain/entities.py` con clases Approval y Decision
- Tests unitarios en `tests/test_entities.py`

## Reglas de negocio implementadas
- Una Approval no puede transicionar dos veces (no se aprueba dos veces ni se rechaza una ya aprobada)
- Las decisiones de tipo REJECT y REQUEST_CHANGES requieren comentario obligatorio
- Las entidades no dependen de SQLAlchemy ni FastAPI (arquitectura hexagonal)

## Cómo probar
```bash
cd backend
pytest tests/test_entities.py -v
```

Closes #22 