### PR TITLE
feat(application): add use cases with Command and Strategy patterns

### DIFF
--- a/backend/app/application/commands.py
+++ b/backend/app/application/commands.py
@@ -1,0 +1,74 @@
+"""
+Patrón Command: cada acción del aprobador es un objeto ejecutable.
+
+Beneficios:
+- Permite encolar, loguear, auditar y eventualmente deshacer (undo) acciones
+- Desacopla el "qué se quiere hacer" del "cómo se hace"
+- Facilita aplicar Template Method o decoradores en el futuro
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Optional
+from uuid import UUID
+
+
+@dataclass
+class CommandResult:
+    """Resultado estandarizado para todos los comandos."""
+    success: bool
+    message: str
+    data: Optional[dict] = None
+
+
+class Command(ABC):
+    """Interfaz base del patrón Command."""
+
+    @abstractmethod
+    def execute(self) -> CommandResult:
+        ...
+
+    def undo(self) -> CommandResult:
+        """Hook opcional para deshacer la acción."""
+        return CommandResult(
+            success=False, message="Esta acción no soporta undo."
+        )
+
+
+@dataclass
+class ApproveCommand(Command):
+    approval_id: UUID
+    reviewer_id: UUID
+    use_case: "ApproveRequestUseCase"  # forward ref, se resuelve en runtime
+
+    def execute(self) -> CommandResult:
+        return self.use_case.run(
+            approval_id=self.approval_id, reviewer_id=self.reviewer_id
+        )
+
+
+@dataclass
+class RejectCommand(Command):
+    approval_id: UUID
+    reviewer_id: UUID
+    comment: str
+    use_case: "RejectRequestUseCase"
+
+    def execute(self) -> CommandResult:
+        return self.use_case.run(
+            approval_id=self.approval_id,
+            reviewer_id=self.reviewer_id,
+            comment=self.comment,
+        )
+
+
+@dataclass
+class AssignCommand(Command):
+    request_id: UUID
+    reviewer_id: UUID
+    use_case: "AssignReviewerUseCase"
+
+    def execute(self) -> CommandResult:
+        return self.use_case.run(
+            request_id=self.request_id, reviewer_id=self.reviewer_id
+        )

--- a/backend/app/application/use_cases/approve_request.py
+++ b/backend/app/application/use_cases/approve_request.py
@@ -1,0 +1,89 @@
+"""Caso de uso: aprobar una solicitud de cambio."""
+
+from uuid import UUID
+
+from app.application.commands import CommandResult
+from app.domain.enums import DecisionAction, RequestStatus
+from app.domain.entities import Decision
+from app.domain.exceptions import (
+    BusinessRuleViolationError,
+    InvalidStateTransitionError,
+)
+from app.domain.policies import policy_for
+from app.domain.repositories import ApprovalRepository, ChangeRequestRepository
+from app.domain.state_machine import (
+    ChangeRequestContext,
+    state_from_status,
+)
+
+
+class ApproveRequestUseCase:
+    """
+    Marca una Approval como aprobada y, si la policy lo permite,
+    transiciona la solicitud principal a APPROVED.
+    """
+
+    def __init__(
+        self,
+        approval_repo: ApprovalRepository,
+        request_repo: ChangeRequestRepository,
+    ):
+        self.approval_repo = approval_repo
+        self.request_repo = request_repo
+
+    def run(self, approval_id: UUID, reviewer_id: UUID) -> CommandResult:
+        approval = self.approval_repo.get_by_id(approval_id)
+        if approval is None:
+            return CommandResult(success=False, message="Approval no encontrada.")
+
+        if approval.reviewer_id != reviewer_id:
+            return CommandResult(
+                success=False,
+                message="No autorizado: la approval pertenece a otro reviewer.",
+            )
+
+        try:
+            approval.mark_approved()
+        except ValueError as e:
+            return CommandResult(success=False, message=str(e))
+
+        self.approval_repo.save(approval)
+        self.approval_repo.save_decision(
+            Decision(approval_id=approval.id, action=DecisionAction.APPROVE)
+        )
+
+        # ¿Se cumple la policy para transicionar la solicitud completa?
+        risk_level = self.request_repo.get_risk_level(approval.request_id)
+        policy = policy_for(risk_level)
+        approved_count = self.approval_repo.count_approved_for_request(
+            approval.request_id
+        )
+
+        if policy.is_satisfied(approved_count):
+            current_status = self.request_repo.get_status(approval.request_id)
+            state = state_from_status(current_status)
+            ctx = ChangeRequestContext(
+                risk_level=risk_level,
+                approvals_count=approved_count,
+            )
+            try:
+                new_state = state.approve(ctx)
+                self.request_repo.update_status(
+                    approval.request_id, new_state.status
+                )
+                return CommandResult(
+                    success=True,
+                    message="Solicitud aprobada completamente.",
+                    data={"new_status": new_state.status.value},
+                )
+            except (InvalidStateTransitionError, BusinessRuleViolationError) as e:
+                return CommandResult(success=False, message=str(e))
+
+        return CommandResult(
+            success=True,
+            message=(
+                f"Aprobación registrada. Faltan "
+                f"{policy.required_approvals() - approved_count} "
+                f"aprobación(es) más."
+            ),
+        )

--- a/backend/app/application/use_cases/assign_reviewer.py
+++ b/backend/app/application/use_cases/assign_reviewer.py
@@ -1,0 +1,60 @@
+"""Caso de uso: asignar un reviewer a una solicitud de cambio."""
+
+from uuid import UUID
+
+from app.application.commands import CommandResult
+from app.domain.entities import Approval
+from app.domain.policies import policy_for
+from app.domain.repositories import ApprovalRepository, ChangeRequestRepository
+
+
+class AssignReviewerUseCase:
+    """
+    Asigna uno o más reviewers a una solicitud creando Approvals pendientes.
+    La cantidad necesaria depende de la policy según el risk level.
+    """
+
+    def __init__(
+        self,
+        approval_repo: ApprovalRepository,
+        request_repo: ChangeRequestRepository,
+    ):
+        self.approval_repo = approval_repo
+        self.request_repo = request_repo
+
+    def run(self, request_id: UUID, reviewer_id: UUID) -> CommandResult:
+        # Validar que la solicitud exista
+        risk_level = self.request_repo.get_risk_level(request_id)
+        if risk_level is None:
+            return CommandResult(
+                success=False, message="Solicitud no encontrada."
+            )
+
+        # Validar que no se exceda la policy
+        policy = policy_for(risk_level)
+        existing = self.approval_repo.list_by_request(request_id)
+        if len(existing) >= policy.required_approvals():
+            return CommandResult(
+                success=False,
+                message=(
+                    f"Ya hay {len(existing)} reviewer(s) asignado(s). "
+                    f"La policy permite máximo {policy.required_approvals()}."
+                ),
+            )
+
+        # Validar que no se asigne dos veces al mismo reviewer
+        for ap in existing:
+            if ap.reviewer_id == reviewer_id:
+                return CommandResult(
+                    success=False,
+                    message="Este reviewer ya está asignado a la solicitud.",
+                )
+
+        approval = Approval(request_id=request_id, reviewer_id=reviewer_id)
+        saved = self.approval_repo.save(approval)
+
+        return CommandResult(
+            success=True,
+            message="Reviewer asignado exitosamente.",
+            data={"approval_id": str(saved.id)},
+        )

--- a/backend/app/application/use_cases/reject_request.py
+++ b/backend/app/application/use_cases/reject_request.py
@@ -1,0 +1,80 @@
+"""Caso de uso: rechazar una solicitud de cambio."""
+
+from uuid import UUID
+
+from app.application.commands import CommandResult
+from app.domain.enums import DecisionAction
+from app.domain.entities import Decision
+from app.domain.exceptions import (
+    BusinessRuleViolationError,
+    InvalidStateTransitionError,
+)
+from app.domain.repositories import ApprovalRepository, ChangeRequestRepository
+from app.domain.state_machine import (
+    ChangeRequestContext,
+    state_from_status,
+)
+
+
+class RejectRequestUseCase:
+    """
+    Marca una Approval como rechazada y transiciona la solicitud completa
+    a REJECTED. Un único rechazo es suficiente para tumbar la solicitud.
+    """
+
+    def __init__(
+        self,
+        approval_repo: ApprovalRepository,
+        request_repo: ChangeRequestRepository,
+    ):
+        self.approval_repo = approval_repo
+        self.request_repo = request_repo
+
+    def run(
+        self, approval_id: UUID, reviewer_id: UUID, comment: str
+    ) -> CommandResult:
+        if not comment or not comment.strip():
+            return CommandResult(
+                success=False, message="El rechazo requiere un comentario."
+            )
+
+        approval = self.approval_repo.get_by_id(approval_id)
+        if approval is None:
+            return CommandResult(success=False, message="Approval no encontrada.")
+
+        if approval.reviewer_id != reviewer_id:
+            return CommandResult(
+                success=False,
+                message="No autorizado: la approval pertenece a otro reviewer.",
+            )
+
+        try:
+            approval.mark_rejected()
+        except ValueError as e:
+            return CommandResult(success=False, message=str(e))
+
+        self.approval_repo.save(approval)
+        self.approval_repo.save_decision(
+            Decision(
+                approval_id=approval.id,
+                action=DecisionAction.REJECT,
+                comment=comment,
+            )
+        )
+
+        # Tumbar la solicitud completa
+        current_status = self.request_repo.get_status(approval.request_id)
+        risk_level = self.request_repo.get_risk_level(approval.request_id)
+        state = state_from_status(current_status)
+        ctx = ChangeRequestContext(risk_level=risk_level)
+
+        try:
+            new_state = state.reject(ctx)
+            self.request_repo.update_status(approval.request_id, new_state.status)
+            return CommandResult(
+                success=True,
+                message="Solicitud rechazada.",
+                data={"new_status": new_state.status.value},
+            )
+        except (InvalidStateTransitionError, BusinessRuleViolationError) as e:
+            return CommandResult(success=False, message=str(e))

--- a/backend/app/domain/policies.py
+++ b/backend/app/domain/policies.py
@@ -1,0 +1,50 @@
+"""
+Patrón Strategy: política de aprobación según risk level.
+
+Diferentes niveles de riesgo requieren diferentes reglas de aprobación.
+En lugar de hardcodear if/else en los casos de uso, encapsulamos cada
+estrategia en su propia clase.
+"""
+
+from abc import ABC, abstractmethod
+
+from app.domain.enums import RiskLevel
+
+
+class ApprovalPolicy(ABC):
+    """Strategy base. Define cuántas aprobaciones se necesitan."""
+
+    @abstractmethod
+    def required_approvals(self) -> int:
+        ...
+
+    @abstractmethod
+    def is_satisfied(self, current_approvals: int) -> bool:
+        ...
+
+
+class SingleApprovalPolicy(ApprovalPolicy):
+    """Política para LOW y MEDIUM risk: una sola aprobación basta."""
+
+    def required_approvals(self) -> int:
+        return 1
+
+    def is_satisfied(self, current_approvals: int) -> bool:
+        return current_approvals >= 1
+
+
+class DualApprovalPolicy(ApprovalPolicy):
+    """Política para HIGH risk: requiere dos aprobaciones independientes."""
+
+    def required_approvals(self) -> int:
+        return 2
+
+    def is_satisfied(self, current_approvals: int) -> bool:
+        return current_approvals >= 2
+
+
+def policy_for(risk_level: RiskLevel) -> ApprovalPolicy:
+    """Factory que devuelve la policy adecuada según el risk level."""
+    if risk_level == RiskLevel.HIGH:
+        return DualApprovalPolicy()
+    return SingleApprovalPolicy()

--- a/backend/app/domain/repositories.py
+++ b/backend/app/domain/repositories.py
@@ -1,0 +1,64 @@
+"""
+Interfaces de repositorio (puertos del dominio).
+
+Estas interfaces son lo que los casos de uso conocen. Las implementaciones
+concretas viven en `infrastructure/repositories/` y se inyectan en runtime.
+Esto cumple con la inversión de dependencias de la arquitectura hexagonal:
+el dominio no depende de SQLAlchemy ni de ningún detalle de persistencia.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Optional, List
+from uuid import UUID
+
+from app.domain.entities import Approval, Decision
+
+
+class ApprovalRepository(ABC):
+    """Puerto para persistencia de Approvals y Decisions."""
+
+    @abstractmethod
+    def get_by_id(self, approval_id: UUID) -> Optional[Approval]:
+        ...
+
+    @abstractmethod
+    def list_by_request(self, request_id: UUID) -> List[Approval]:
+        ...
+
+    @abstractmethod
+    def list_pending_for_reviewer(self, reviewer_id: UUID) -> List[Approval]:
+        ...
+
+    @abstractmethod
+    def save(self, approval: Approval) -> Approval:
+        ...
+
+    @abstractmethod
+    def save_decision(self, decision: Decision) -> Decision:
+        ...
+
+    @abstractmethod
+    def count_approved_for_request(self, request_id: UUID) -> int:
+        ...
+
+
+class ChangeRequestRepository(ABC):
+    """Puerto mínimo para leer/actualizar el estado de la solicitud principal."""
+
+    @abstractmethod
+    def get_status(self, request_id: UUID):
+        """Devuelve el RequestStatus actual."""
+        ...
+
+    @abstractmethod
+    def update_status(self, request_id: UUID, new_status) -> None:
+        """Persiste el nuevo estado tras una transición válida."""
+        ...
+
+    @abstractmethod
+    def get_risk_level(self, request_id: UUID):
+        ...
+
+    @abstractmethod
+    def has_rollback_plan(self, request_id: UUID) -> bool:
+        ...

--- a/backend/app/tests/test_use_cases.py
+++ b/backend/app/tests/test_use_cases.py
@@ -1,0 +1,255 @@
+"""Tests de casos de uso usando repositorios fake en memoria."""
+
+from typing import Optional, List
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.application.use_cases.approve_request import ApproveRequestUseCase
+from app.application.use_cases.reject_request import RejectRequestUseCase
+from app.application.use_cases.assign_reviewer import AssignReviewerUseCase
+from app.domain.entities import Approval, Decision
+from app.domain.enums import ApprovalStatus, RequestStatus, RiskLevel
+from app.domain.repositories import ApprovalRepository, ChangeRequestRepository
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+class FakeApprovalRepository(ApprovalRepository):
+    def __init__(self):
+        self.approvals: dict[UUID, Approval] = {}
+        self.decisions: List[Decision] = []
+
+    def get_by_id(self, approval_id: UUID) -> Optional[Approval]:
+        return self.approvals.get(approval_id)
+
+    def list_by_request(self, request_id: UUID) -> List[Approval]:
+        return [a for a in self.approvals.values() if a.request_id == request_id]
+
+    def list_pending_for_reviewer(self, reviewer_id: UUID) -> List[Approval]:
+        return [
+            a for a in self.approvals.values()
+            if a.reviewer_id == reviewer_id and a.is_pending()
+        ]
+
+    def save(self, approval: Approval) -> Approval:
+        self.approvals[approval.id] = approval
+        return approval
+
+    def save_decision(self, decision: Decision) -> Decision:
+        self.decisions.append(decision)
+        return decision
+
+    def count_approved_for_request(self, request_id: UUID) -> int:
+        return sum(
+            1 for a in self.approvals.values()
+            if a.request_id == request_id and a.status == ApprovalStatus.APPROVED
+        )
+
+
+class FakeChangeRequestRepository(ChangeRequestRepository):
+    def __init__(
+        self,
+        request_id: UUID,
+        status: RequestStatus,
+        risk_level: RiskLevel,
+        has_rollback: bool = True,
+    ):
+        self.request_id = request_id
+        self.status = status
+        self.risk_level = risk_level
+        self.has_rollback = has_rollback
+
+    def get_status(self, request_id: UUID):
+        return self.status if request_id == self.request_id else None
+
+    def update_status(self, request_id: UUID, new_status) -> None:
+        self.status = new_status
+
+    def get_risk_level(self, request_id: UUID):
+        return self.risk_level if request_id == self.request_id else None
+
+    def has_rollback_plan(self, request_id: UUID) -> bool:
+        return self.has_rollback
+
+
+# ---------------------------------------------------------------------------
+# ApproveRequestUseCase
+# ---------------------------------------------------------------------------
+
+class TestApproveRequest:
+    def test_low_risk_single_approval_completes_request(self):
+        request_id = uuid4()
+        reviewer_id = uuid4()
+        approval = Approval(request_id=request_id, reviewer_id=reviewer_id)
+
+        approval_repo = FakeApprovalRepository()
+        approval_repo.save(approval)
+        request_repo = FakeChangeRequestRepository(
+            request_id=request_id,
+            status=RequestStatus.IN_REVIEW,
+            risk_level=RiskLevel.LOW,
+        )
+
+        use_case = ApproveRequestUseCase(approval_repo, request_repo)
+        result = use_case.run(approval.id, reviewer_id)
+
+        assert result.success
+        assert request_repo.status == RequestStatus.APPROVED
+
+    def test_high_risk_first_approval_does_not_complete(self):
+        request_id = uuid4()
+        reviewer_id_1 = uuid4()
+        approval = Approval(request_id=request_id, reviewer_id=reviewer_id_1)
+
+        approval_repo = FakeApprovalRepository()
+        approval_repo.save(approval)
+        request_repo = FakeChangeRequestRepository(
+            request_id=request_id,
+            status=RequestStatus.IN_REVIEW,
+            risk_level=RiskLevel.HIGH,
+        )
+
+        use_case = ApproveRequestUseCase(approval_repo, request_repo)
+        result = use_case.run(approval.id, reviewer_id_1)
+
+        assert result.success
+        assert request_repo.status == RequestStatus.IN_REVIEW  # sigue en review
+
+    def test_unauthorized_reviewer_rejected(self):
+        request_id = uuid4()
+        actual_reviewer = uuid4()
+        intruder = uuid4()
+        approval = Approval(request_id=request_id, reviewer_id=actual_reviewer)
+
+        approval_repo = FakeApprovalRepository()
+        approval_repo.save(approval)
+        request_repo = FakeChangeRequestRepository(
+            request_id=request_id,
+            status=RequestStatus.IN_REVIEW,
+            risk_level=RiskLevel.LOW,
+        )
+
+        use_case = ApproveRequestUseCase(approval_repo, request_repo)
+        result = use_case.run(approval.id, intruder)
+
+        assert not result.success
+        assert "autorizado" in result.message.lower()
+
+
+# ---------------------------------------------------------------------------
+# RejectRequestUseCase
+# ---------------------------------------------------------------------------
+
+class TestRejectRequest:
+    def test_reject_requires_comment(self):
+        request_id = uuid4()
+        reviewer_id = uuid4()
+        approval = Approval(request_id=request_id, reviewer_id=reviewer_id)
+
+        approval_repo = FakeApprovalRepository()
+        approval_repo.save(approval)
+        request_repo = FakeChangeRequestRepository(
+            request_id=request_id,
+            status=RequestStatus.IN_REVIEW,
+            risk_level=RiskLevel.LOW,
+        )
+
+        use_case = RejectRequestUseCase(approval_repo, request_repo)
+        result = use_case.run(approval.id, reviewer_id, comment="")
+
+        assert not result.success
+        assert "comentario" in result.message.lower()
+
+    def test_reject_transitions_request_to_rejected(self):
+        request_id = uuid4()
+        reviewer_id = uuid4()
+        approval = Approval(request_id=request_id, reviewer_id=reviewer_id)
+
+        approval_repo = FakeApprovalRepository()
+        approval_repo.save(approval)
+        request_repo = FakeChangeRequestRepository(
+            request_id=request_id,
+            status=RequestStatus.IN_REVIEW,
+            risk_level=RiskLevel.HIGH,
+        )
+
+        use_case = RejectRequestUseCase(approval_repo, request_repo)
+        result = use_case.run(
+            approval.id, reviewer_id, comment="Falta plan de rollback"
+        )
+
+        assert result.success
+        assert request_repo.status == RequestStatus.REJECTED
+
+
+# ---------------------------------------------------------------------------
+# AssignReviewerUseCase
+# ---------------------------------------------------------------------------
+
+class TestAssignReviewer:
+    def test_assign_low_risk_one_reviewer_ok(self):
+        request_id = uuid4()
+        reviewer_id = uuid4()
+
+        approval_repo = FakeApprovalRepository()
+        request_repo = FakeChangeRequestRepository(
+            request_id=request_id,
+            status=RequestStatus.SUBMITTED,
+            risk_level=RiskLevel.LOW,
+        )
+
+        use_case = AssignReviewerUseCase(approval_repo, request_repo)
+        result = use_case.run(request_id, reviewer_id)
+
+        assert result.success
+        assert len(approval_repo.list_by_request(request_id)) == 1
+
+    def test_assign_high_risk_allows_two_reviewers(self):
+        request_id = uuid4()
+        reviewer_a = uuid4()
+        reviewer_b = uuid4()
+
+        approval_repo = FakeApprovalRepository()
+        request_repo = FakeChangeRequestRepository(
+            request_id=request_id,
+            status=RequestStatus.SUBMITTED,
+            risk_level=RiskLevel.HIGH,
+        )
+
+        use_case = AssignReviewerUseCase(approval_repo, request_repo)
+        assert use_case.run(request_id, reviewer_a).success
+        assert use_case.run(request_id, reviewer_b).success
+        assert len(approval_repo.list_by_request(request_id)) == 2
+
+    def test_cannot_exceed_policy_limit(self):
+        request_id = uuid4()
+        approval_repo = FakeApprovalRepository()
+        request_repo = FakeChangeRequestRepository(
+            request_id=request_id,
+            status=RequestStatus.SUBMITTED,
+            risk_level=RiskLevel.LOW,  # solo permite 1
+        )
+
+        use_case = AssignReviewerUseCase(approval_repo, request_repo)
+        assert use_case.run(request_id, uuid4()).success
+        result = use_case.run(request_id, uuid4())  # segundo intento
+        assert not result.success
+        assert "policy" in result.message.lower() or "máximo" in result.message.lower()
+
+    def test_cannot_assign_same_reviewer_twice(self):
+        request_id = uuid4()
+        reviewer_id = uuid4()
+        approval_repo = FakeApprovalRepository()
+        request_repo = FakeChangeRequestRepository(
+            request_id=request_id,
+            status=RequestStatus.SUBMITTED,
+            risk_level=RiskLevel.HIGH,
+        )
+
+        use_case = AssignReviewerUseCase(approval_repo, request_repo)
+        assert use_case.run(request_id, reviewer_id).success
+        result = use_case.run(request_id, reviewer_id)
+        assert not result.success


### PR DESCRIPTION
## Descripción
Implementa los casos de uso de aprobación, rechazo y asignación, aplicando 
los patrones Command y Strategy.

> ⚠️ Stacked PR: este PR depende de #23 . La base es 
> `feat/state-machine`. Una vez que el PR del Issue 2 se mergee a dev, 
> la base se cambiará automáticamente a dev.

## Cambios
- `domain/repositories.py`: interfaces ApprovalRepository y ChangeRequestRepository
- `domain/policies.py`: ApprovalPolicy con SingleApprovalPolicy y DualApprovalPolicy
- `application/commands.py`: ApproveCommand, RejectCommand, AssignCommand
- `application/use_cases/approve_request.py`
- `application/use_cases/reject_request.py`
- `application/use_cases/assign_reviewer.py`
- `tests/test_use_cases.py`: tests con repositorios fake en memoria

## Patrones aplicados
- **Strategy**: ApprovalPolicy decide cuántas aprobaciones se necesitan según risk level
- **Command**: cada acción es un objeto ejecutable con execute() y undo() opcional

## Reglas de negocio
- HIGH risk requiere 2 aprobaciones (DualApprovalPolicy)
- LOW y MEDIUM risk requieren 1 aprobación (SingleApprovalPolicy)
- El rechazo requiere comentario obligatorio
- No se permite asignar dos veces al mismo reviewer
- No autorizado si el reviewer no es el dueño de la approval

## Cómo probar
\`\`\`
cd backend
pytest tests/test_use_cases.py -v
\`\`\`

Closes #24 