### PR TITLE
feat(infra,api): add approval repository and HTTP endpoints

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -1,0 +1,74 @@
+"""
+Dependencies de FastAPI: inyección de repositorios, casos de uso y usuario actual.
+"""
+
+from uuid import UUID
+
+from fastapi import Depends, Header, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.application.use_cases.approve_request import ApproveRequestUseCase
+from app.application.use_cases.assign_reviewer import AssignReviewerUseCase
+from app.application.use_cases.reject_request import RejectRequestUseCase
+from app.infrastructure.db.session import get_db
+from app.infrastructure.repositories.approval_repository import (
+    SQLAlchemyApprovalRepository,
+)
+from app.infrastructure.repositories.change_request_repository import (
+    SQLAlchemyChangeRequestRepository,
+)
+
+
+# ---- Repositorios ----
+
+def get_approval_repo(db: Session = Depends(get_db)):
+    return SQLAlchemyApprovalRepository(db)
+
+
+def get_change_request_repo(db: Session = Depends(get_db)):
+    return SQLAlchemyChangeRequestRepository(db)
+
+
+# ---- Casos de uso ----
+
+def get_approve_use_case(
+    approval_repo=Depends(get_approval_repo),
+    request_repo=Depends(get_change_request_repo),
+):
+    return ApproveRequestUseCase(approval_repo, request_repo)
+
+
+def get_reject_use_case(
+    approval_repo=Depends(get_approval_repo),
+    request_repo=Depends(get_change_request_repo),
+):
+    return RejectRequestUseCase(approval_repo, request_repo)
+
+
+def get_assign_use_case(
+    approval_repo=Depends(get_approval_repo),
+    request_repo=Depends(get_change_request_repo),
+):
+    return AssignReviewerUseCase(approval_repo, request_repo)
+
+
+# ---- Usuario actual (placeholder) ----
+
+def get_current_user_id(x_user_id: str = Header(None)) -> UUID:
+    """
+    Placeholder de autenticación. Cuando se implemente JWT, esto se
+    reemplaza por una dependencia que decodifique el token.
+    Por ahora, espera el header X-User-Id.
+    """
+    if not x_user_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Falta header X-User-Id (placeholder de auth).",
+        )
+    try:
+        return UUID(x_user_id)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="X-User-Id no es un UUID válido.",
+        )

--- a/backend/app/api/routes/requests.py
+++ b/backend/app/api/routes/requests.py
@@ -1,0 +1,97 @@
+"""Endpoints de aprobación, rechazo y asignación de reviewers."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.api.dependencies import (
+    get_approve_use_case,
+    get_assign_use_case,
+    get_current_user_id,
+    get_reject_use_case,
+)
+from app.api.schemas import (
+    ActionResponse,
+    AssignReviewerRequest,
+    RejectRequest,
+)
+from app.application.use_cases.approve_request import ApproveRequestUseCase
+from app.application.use_cases.assign_reviewer import AssignReviewerUseCase
+from app.application.use_cases.reject_request import RejectRequestUseCase
+
+router = APIRouter(prefix="/requests", tags=["approvals"])
+
+
+@router.post(
+    "/{approval_id}/approve",
+    response_model=ActionResponse,
+    status_code=status.HTTP_200_OK,
+)
+def approve_request(
+    approval_id: UUID,
+    current_user: UUID = Depends(get_current_user_id),
+    use_case: ApproveRequestUseCase = Depends(get_approve_use_case),
+):
+    result = use_case.run(approval_id=approval_id, reviewer_id=current_user)
+    if not result.success:
+        # Diferenciar autorización vs. otros errores
+        if "autorizado" in result.message.lower():
+            raise HTTPException(status_code=403, detail=result.message)
+        if "no encontrada" in result.message.lower():
+            raise HTTPException(status_code=404, detail=result.message)
+        raise HTTPException(status_code=400, detail=result.message)
+    return ActionResponse(
+        success=True,
+        message=result.message,
+        new_status=(result.data or {}).get("new_status"),
+    )
+
+
+@router.post(
+    "/{approval_id}/reject",
+    response_model=ActionResponse,
+    status_code=status.HTTP_200_OK,
+)
+def reject_request(
+    approval_id: UUID,
+    payload: RejectRequest,
+    current_user: UUID = Depends(get_current_user_id),
+    use_case: RejectRequestUseCase = Depends(get_reject_use_case),
+):
+    result = use_case.run(
+        approval_id=approval_id,
+        reviewer_id=current_user,
+        comment=payload.comment,
+    )
+    if not result.success:
+        if "autorizado" in result.message.lower():
+            raise HTTPException(status_code=403, detail=result.message)
+        if "no encontrada" in result.message.lower():
+            raise HTTPException(status_code=404, detail=result.message)
+        raise HTTPException(status_code=400, detail=result.message)
+    return ActionResponse(
+        success=True,
+        message=result.message,
+        new_status=(result.data or {}).get("new_status"),
+    )
+
+
+@router.post(
+    "/{request_id}/assign",
+    response_model=ActionResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def assign_reviewer(
+    request_id: UUID,
+    payload: AssignReviewerRequest,
+    _current_user: UUID = Depends(get_current_user_id),
+    use_case: AssignReviewerUseCase = Depends(get_assign_use_case),
+):
+    result = use_case.run(
+        request_id=request_id, reviewer_id=payload.reviewer_id
+    )
+    if not result.success:
+        if "no encontrada" in result.message.lower():
+            raise HTTPException(status_code=404, detail=result.message)
+        raise HTTPException(status_code=400, detail=result.message)
+    return ActionResponse(success=True, message=result.message)

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -1,0 +1,32 @@
+"""DTOs (Pydantic schemas) de entrada y salida de la API."""
+
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from app.domain.enums import ApprovalStatus
+
+
+class AssignReviewerRequest(BaseModel):
+    reviewer_id: UUID
+
+
+class RejectRequest(BaseModel):
+    comment: str = Field(..., min_length=1)
+
+
+class ApprovalResponse(BaseModel):
+    id: UUID
+    request_id: UUID
+    reviewer_id: UUID
+    status: ApprovalStatus
+    created_at: datetime
+    decided_at: Optional[datetime]
+
+
+class ActionResponse(BaseModel):
+    success: bool
+    message: str
+    new_status: Optional[str] = None

--- a/backend/app/infrastructure/db/__init__.py
+++ b/backend/app/infrastructure/db/__init__.py
@@ -1,0 +1,8 @@
+"""Configuración base de SQLAlchemy."""
+
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    """Base declarativa común para todos los modelos ORM."""
+    pass

--- a/backend/app/infrastructure/db/base.py
+++ b/backend/app/infrastructure/db/base.py
@@ -1,0 +1,8 @@
+"""Configuración base de SQLAlchemy."""
+
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    """Base declarativa común para todos los modelos ORM."""
+    pass

--- a/backend/app/infrastructure/db/models.py
+++ b/backend/app/infrastructure/db/models.py
@@ -1,0 +1,88 @@
+"""
+Modelos ORM (SQLAlchemy).
+
+Estos modelos viven en infraestructura, NO en el dominio. Son traducciones
+1-a-1 de las entidades de dominio para persistir en PostgreSQL.
+
+Nota: ChangeRequestModel es un placeholder mínimo. El compañero a cargo de
+la entidad principal puede extenderlo con los campos que necesite.
+"""
+
+from datetime import datetime
+from uuid import uuid4
+
+from sqlalchemy import Column, DateTime, Enum as SAEnum, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import relationship
+
+from app.domain.enums import (
+    ApprovalStatus,
+    DecisionAction,
+    RequestStatus,
+    RiskLevel,
+)
+from app.infrastructure.db.base import Base
+
+
+class ChangeRequestModel(Base):
+    """
+    Modelo placeholder de ChangeRequest. Solo incluye lo que necesita
+    la feature de aprobación. Persona X que maneje la entidad principal
+    puede extender este modelo o reemplazarlo y mantener los campos.
+    """
+    __tablename__ = "change_requests"
+
+    id = Column(PGUUID(as_uuid=True), primary_key=True, default=uuid4)
+    title = Column(String(200), nullable=False, default="")
+    status = Column(
+        SAEnum(RequestStatus, name="request_status"),
+        nullable=False,
+        default=RequestStatus.DRAFT,
+    )
+    risk_level = Column(
+        SAEnum(RiskLevel, name="risk_level"),
+        nullable=False,
+        default=RiskLevel.LOW,
+    )
+    rollback_plan = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+
+class ApprovalModel(Base):
+    __tablename__ = "approvals"
+
+    id = Column(PGUUID(as_uuid=True), primary_key=True, default=uuid4)
+    request_id = Column(
+        PGUUID(as_uuid=True),
+        ForeignKey("change_requests.id"),
+        nullable=False,
+    )
+    reviewer_id = Column(PGUUID(as_uuid=True), nullable=False)
+    status = Column(
+        SAEnum(ApprovalStatus, name="approval_status"),
+        nullable=False,
+        default=ApprovalStatus.PENDING,
+    )
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    decided_at = Column(DateTime, nullable=True)
+
+    decisions = relationship("DecisionModel", back_populates="approval")
+
+
+class DecisionModel(Base):
+    __tablename__ = "decisions"
+
+    id = Column(PGUUID(as_uuid=True), primary_key=True, default=uuid4)
+    approval_id = Column(
+        PGUUID(as_uuid=True),
+        ForeignKey("approvals.id"),
+        nullable=False,
+    )
+    action = Column(
+        SAEnum(DecisionAction, name="decision_action"),
+        nullable=False,
+    )
+    comment = Column(Text, nullable=True)
+    decided_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    approval = relationship("ApprovalModel", back_populates="decisions")

--- a/backend/app/infrastructure/db/session.py
+++ b/backend/app/infrastructure/db/session.py
@@ -1,0 +1,23 @@
+"""Configuración de la sesión de SQLAlchemy."""
+
+import os
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql://user:password@db:5432/appdb",
+)
+
+engine = create_engine(DATABASE_URL, pool_pre_ping=True)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def get_db():
+    """Dependency de FastAPI: provee una sesión por request."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/app/infrastructure/repositories/approval_repository.py
+++ b/backend/app/infrastructure/repositories/approval_repository.py
@@ -1,0 +1,99 @@
+"""Implementación concreta de ApprovalRepository usando SQLAlchemy."""
+
+from typing import List, Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.domain.entities import Approval, Decision
+from app.domain.enums import ApprovalStatus
+from app.domain.repositories import ApprovalRepository
+from app.infrastructure.db.models import ApprovalModel, DecisionModel
+
+
+class SQLAlchemyApprovalRepository(ApprovalRepository):
+    """Adapter concreto: convierte entre entidades de dominio y modelos ORM."""
+
+    def __init__(self, session: Session):
+        self.session = session
+
+    # ----- mappers -----
+
+    @staticmethod
+    def _to_entity(model: ApprovalModel) -> Approval:
+        return Approval(
+            id=model.id,
+            request_id=model.request_id,
+            reviewer_id=model.reviewer_id,
+            status=model.status,
+            created_at=model.created_at,
+            decided_at=model.decided_at,
+        )
+
+    @staticmethod
+    def _to_model(entity: Approval) -> ApprovalModel:
+        return ApprovalModel(
+            id=entity.id,
+            request_id=entity.request_id,
+            reviewer_id=entity.reviewer_id,
+            status=entity.status,
+            created_at=entity.created_at,
+            decided_at=entity.decided_at,
+        )
+
+    # ----- métodos del puerto -----
+
+    def get_by_id(self, approval_id: UUID) -> Optional[Approval]:
+        model = self.session.get(ApprovalModel, approval_id)
+        return self._to_entity(model) if model else None
+
+    def list_by_request(self, request_id: UUID) -> List[Approval]:
+        models = (
+            self.session.query(ApprovalModel)
+            .filter(ApprovalModel.request_id == request_id)
+            .all()
+        )
+        return [self._to_entity(m) for m in models]
+
+    def list_pending_for_reviewer(self, reviewer_id: UUID) -> List[Approval]:
+        models = (
+            self.session.query(ApprovalModel)
+            .filter(
+                ApprovalModel.reviewer_id == reviewer_id,
+                ApprovalModel.status == ApprovalStatus.PENDING,
+            )
+            .all()
+        )
+        return [self._to_entity(m) for m in models]
+
+    def save(self, approval: Approval) -> Approval:
+        existing = self.session.get(ApprovalModel, approval.id)
+        if existing:
+            existing.status = approval.status
+            existing.decided_at = approval.decided_at
+        else:
+            self.session.add(self._to_model(approval))
+        self.session.commit()
+        return approval
+
+    def save_decision(self, decision: Decision) -> Decision:
+        model = DecisionModel(
+            id=decision.id,
+            approval_id=decision.approval_id,
+            action=decision.action,
+            comment=decision.comment,
+            decided_at=decision.decided_at,
+        )
+        self.session.add(model)
+        self.session.commit()
+        return decision
+
+    def count_approved_for_request(self, request_id: UUID) -> int:
+        return (
+            self.session.query(ApprovalModel)
+            .filter(
+                ApprovalModel.request_id == request_id,
+                ApprovalModel.status == ApprovalStatus.APPROVED,
+            )
+            .count()
+        )

--- a/backend/app/infrastructure/repositories/change_request_repository.py
+++ b/backend/app/infrastructure/repositories/change_request_repository.py
@@ -1,0 +1,36 @@
+"""Implementación de ChangeRequestRepository usando SQLAlchemy."""
+
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.domain.enums import RequestStatus, RiskLevel
+from app.domain.repositories import ChangeRequestRepository
+from app.infrastructure.db.models import ChangeRequestModel
+
+
+class SQLAlchemyChangeRequestRepository(ChangeRequestRepository):
+    def __init__(self, session: Session):
+        self.session = session
+
+    def _get(self, request_id: UUID) -> Optional[ChangeRequestModel]:
+        return self.session.get(ChangeRequestModel, request_id)
+
+    def get_status(self, request_id: UUID) -> Optional[RequestStatus]:
+        model = self._get(request_id)
+        return model.status if model else None
+
+    def update_status(self, request_id: UUID, new_status: RequestStatus) -> None:
+        model = self._get(request_id)
+        if model:
+            model.status = new_status
+            self.session.commit()
+
+    def get_risk_level(self, request_id: UUID) -> Optional[RiskLevel]:
+        model = self._get(request_id)
+        return model.risk_level if model else None
+
+    def has_rollback_plan(self, request_id: UUID) -> bool:
+        model = self._get(request_id)
+        return bool(model and model.rollback_plan and model.rollback_plan.strip())

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,14 @@
+"""Punto de entrada de la API FastAPI."""
+
+from fastapi import FastAPI
+
+from app.api.routes import requests as requests_router
+
+app = FastAPI(title="ChangeFlow API")
+
+app.include_router(requests_router.router)
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}

--- a/backend/app/tests/test_api_requests.py
+++ b/backend/app/tests/test_api_requests.py
@@ -1,0 +1,126 @@
+"""Tests de los endpoints usando TestClient y override de dependencies."""
+
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.dependencies import (
+    get_approve_use_case,
+    get_assign_use_case,
+    get_reject_use_case,
+)
+from app.application.commands import CommandResult
+from app.main import app
+
+
+# ---------------------------------------------------------------------------
+# Stubs de casos de uso
+# ---------------------------------------------------------------------------
+
+class StubApproveUC:
+    def __init__(self, result: CommandResult):
+        self.result = result
+
+    def run(self, approval_id, reviewer_id):
+        return self.result
+
+
+class StubRejectUC:
+    def __init__(self, result: CommandResult):
+        self.result = result
+
+    def run(self, approval_id, reviewer_id, comment):
+        return self.result
+
+
+class StubAssignUC:
+    def __init__(self, result: CommandResult):
+        self.result = result
+
+    def run(self, request_id, reviewer_id):
+        return self.result
+
+
+client = TestClient(app)
+USER_HEADER = {"X-User-Id": str(uuid4())}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_approve_success():
+    app.dependency_overrides[get_approve_use_case] = lambda: StubApproveUC(
+        CommandResult(success=True, message="ok", data={"new_status": "APPROVED"})
+    )
+    response = client.post(f"/requests/{uuid4()}/approve", headers=USER_HEADER)
+    assert response.status_code == 200
+    assert response.json()["new_status"] == "APPROVED"
+    app.dependency_overrides.clear()
+
+
+def test_approve_unauthorized():
+    app.dependency_overrides[get_approve_use_case] = lambda: StubApproveUC(
+        CommandResult(success=False, message="No autorizado")
+    )
+    response = client.post(f"/requests/{uuid4()}/approve", headers=USER_HEADER)
+    assert response.status_code == 403
+    app.dependency_overrides.clear()
+
+
+def test_approve_without_user_header():
+    response = client.post(f"/requests/{uuid4()}/approve")
+    assert response.status_code == 401
+
+
+def test_reject_requires_comment():
+    response = client.post(
+        f"/requests/{uuid4()}/reject",
+        json={"comment": ""},
+        headers=USER_HEADER,
+    )
+    # Pydantic rechaza por min_length=1
+    assert response.status_code == 422
+
+
+def test_reject_success():
+    app.dependency_overrides[get_reject_use_case] = lambda: StubRejectUC(
+        CommandResult(
+            success=True, message="rechazada", data={"new_status": "REJECTED"}
+        )
+    )
+    response = client.post(
+        f"/requests/{uuid4()}/reject",
+        json={"comment": "Falta plan de rollback"},
+        headers=USER_HEADER,
+    )
+    assert response.status_code == 200
+    assert response.json()["new_status"] == "REJECTED"
+    app.dependency_overrides.clear()
+
+
+def test_assign_success():
+    app.dependency_overrides[get_assign_use_case] = lambda: StubAssignUC(
+        CommandResult(success=True, message="asignado")
+    )
+    response = client.post(
+        f"/requests/{uuid4()}/assign",
+        json={"reviewer_id": str(uuid4())},
+        headers=USER_HEADER,
+    )
+    assert response.status_code == 201
+    app.dependency_overrides.clear()
+
+
+def test_assign_not_found():
+    app.dependency_overrides[get_assign_use_case] = lambda: StubAssignUC(
+        CommandResult(success=False, message="Solicitud no encontrada.")
+    )
+    response = client.post(
+        f"/requests/{uuid4()}/assign",
+        json={"reviewer_id": str(uuid4())},
+        headers=USER_HEADER,
+    )
+    assert response.status_code == 404
+    app.dependency_overrides.clear()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,5 @@ psycopg2-binary
 alembic
 pydantic
 python-dotenv
+pytest
+httpx


### PR DESCRIPTION
## Descripción
Implementa la capa de infraestructura (modelos ORM y repositorios) y los 
endpoints HTTP para aprobar, rechazar y asignar reviewers en solicitudes 
de cambio.

> ⚠️ Stacked PR: depende de #23. Base: `feat/approval-use-cases`.

## Cambios
### Infraestructura
- `infrastructure/db/base.py`: Base declarativa de SQLAlchemy
- `infrastructure/db/models.py`: ApprovalModel, DecisionModel y ChangeRequestModel (placeholder)
- `infrastructure/db/session.py`: configuración de sesión y dependency get_db
- `infrastructure/repositories/approval_repository.py`: SQLAlchemyApprovalRepository
- `infrastructure/repositories/change_request_repository.py`: SQLAlchemyChangeRequestRepository

### API
- `api/schemas.py`: DTOs Pydantic (entrada/salida)
- `api/dependencies.py`: inyección de repos, casos de uso y usuario actual
- `api/routes/requests.py`: endpoints POST /requests/{id}/approve, /reject, /assign
- `main.py`: registro del router

## Endpoints añadidos
- `POST /requests/{approval_id}/approve` → 200 / 403 / 404
- `POST /requests/{approval_id}/reject` → 200 / 403 / 404 / 422
- `POST /requests/{request_id}/assign` → 201 / 400 / 404

## Notas para el equipo
- `ChangeRequestModel` es un **placeholder mínimo** con los campos que requiere 
  la feature de aprobación. Persona X (entidad principal) puede extenderlo o 
  reemplazarlo, manteniendo los campos: `id`, `status`, `risk_level`, `rollback_plan`.
- La autenticación se hace por header `X-User-Id` como placeholder. Cuando 
  Persona Y conecte JWT, `get_current_user_id` se reemplaza por la dependencia real.

## Cómo probar
\`\`\`
cd backend
pytest tests/test_api_requests.py -v
\`\`\`

Closes #25 