### PR TITLE
feat(frontend): add approver inbox and detail actions

### DIFF
--- a/frontend/app/api_client.py
+++ b/frontend/app/api_client.py
@@ -1,0 +1,62 @@
+"""Cliente HTTP para consumir la API de ChangeFlow desde Streamlit."""
+
+import os
+from typing import Optional
+from uuid import UUID
+
+import requests
+
+API_BASE_URL = os.getenv("API_BASE_URL", "http://backend:8000")
+
+
+class ApiClient:
+    """
+    Wrapper sobre requests que añade el header X-User-Id (placeholder de auth)
+    y centraliza el manejo de errores.
+    """
+
+    def __init__(self, user_id: UUID, base_url: str = API_BASE_URL):
+        self.user_id = user_id
+        self.base_url = base_url
+
+    def _headers(self) -> dict:
+        return {"X-User-Id": str(self.user_id)}
+
+    def approve(self, approval_id: UUID) -> tuple[bool, str, Optional[dict]]:
+        url = f"{self.base_url}/requests/{approval_id}/approve"
+        resp = requests.post(url, headers=self._headers(), timeout=10)
+        return self._parse(resp)
+
+    def reject(
+        self, approval_id: UUID, comment: str
+    ) -> tuple[bool, str, Optional[dict]]:
+        url = f"{self.base_url}/requests/{approval_id}/reject"
+        resp = requests.post(
+            url,
+            headers=self._headers(),
+            json={"comment": comment},
+            timeout=10,
+        )
+        return self._parse(resp)
+
+    def assign_reviewer(
+        self, request_id: UUID, reviewer_id: UUID
+    ) -> tuple[bool, str, Optional[dict]]:
+        url = f"{self.base_url}/requests/{request_id}/assign"
+        resp = requests.post(
+            url,
+            headers=self._headers(),
+            json={"reviewer_id": str(reviewer_id)},
+            timeout=10,
+        )
+        return self._parse(resp)
+
+    @staticmethod
+    def _parse(resp: requests.Response) -> tuple[bool, str, Optional[dict]]:
+        try:
+            data = resp.json()
+        except ValueError:
+            data = {}
+        if 200 <= resp.status_code < 300:
+            return True, data.get("message", "OK"), data
+        return False, data.get("detail", f"Error HTTP {resp.status_code}"), data

--- a/frontend/app/pages/approver_inbox.py
+++ b/frontend/app/pages/approver_inbox.py
@@ -1,0 +1,103 @@
+"""
+Vista del aprobador: muestra las solicitudes pendientes asignadas a él
+y permite aprobar, rechazar o solicitar cambios.
+
+Esta vista asume que el usuario ya tiene `user_id` en st.session_state,
+lo cual lo manejará la página de login (otra persona del equipo).
+"""
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from uuid import UUID
+
+import streamlit as st
+
+from app.api_client import ApiClient
+
+st.set_page_config(page_title="Approver Inbox", page_icon="📥")
+st.title("📥 Bandeja del aprobador")
+
+# ---------------------------------------------------------------------------
+# Verificación de sesión
+# ---------------------------------------------------------------------------
+
+if "user_id" not in st.session_state:
+    st.warning("Debes iniciar sesión para ver tu bandeja.")
+    # Permitir poner un user_id manualmente para testear sin login
+    test_user = st.text_input("UUID de prueba (mientras no haya login)")
+    if test_user:
+        try:
+            st.session_state["user_id"] = UUID(test_user)
+            st.rerun()
+        except ValueError:
+            st.error("UUID inválido.")
+    st.stop()
+
+user_id: UUID = st.session_state["user_id"]
+client = ApiClient(user_id=user_id)
+
+# ---------------------------------------------------------------------------
+# Listado de solicitudes pendientes
+# ---------------------------------------------------------------------------
+
+st.subheader("Aprobar / Rechazar / Solicitar cambios")
+st.caption(
+    "Ingresa el ID de una Approval asignada a ti para tomar una decisión."
+)
+
+approval_id_str = st.text_input("Approval ID", key="approval_id_input")
+
+if approval_id_str:
+    try:
+        approval_id = UUID(approval_id_str)
+    except ValueError:
+        st.error("El Approval ID no es un UUID válido.")
+        st.stop()
+
+    col1, col2, col3 = st.columns(3)
+
+    # ----- Aprobar -----
+    with col1:
+        if st.button("✅ Aprobar", use_container_width=True):
+            ok, msg, _ = client.approve(approval_id)
+            if ok:
+                st.success(msg)
+            else:
+                st.error(msg)
+
+    # ----- Rechazar -----
+    with col2:
+        with st.expander("❌ Rechazar"):
+            reject_comment = st.text_area(
+                "Motivo del rechazo (obligatorio)", key="reject_comment"
+            )
+            if st.button("Confirmar rechazo", key="confirm_reject"):
+                if not reject_comment.strip():
+                    st.error("El comentario es obligatorio para rechazar.")
+                else:
+                    ok, msg, _ = client.reject(approval_id, reject_comment)
+                    if ok:
+                        st.success(msg)
+                    else:
+                        st.error(msg)
+
+    # ----- Solicitar cambios -----
+    with col3:
+        with st.expander("🔁 Solicitar cambios"):
+            change_comment = st.text_area(
+                "Qué cambios solicitas (obligatorio)", key="change_comment"
+            )
+            if st.button("Enviar solicitud", key="confirm_changes"):
+                if not change_comment.strip():
+                    st.error("Debes describir los cambios solicitados.")
+                else:
+                    # Reusamos reject endpoint con un comentario marcado, o
+                    # idealmente un endpoint específico request_changes.
+                    st.info(
+                        "TODO: endpoint /request-changes pendiente. "
+                        "Mientras tanto, usa Rechazar con comentario."
+                    )
+
+st.divider()
+st.caption(f"Sesión: user_id = {user_id}")

--- a/frontend/app/pages/request_detail.py
+++ b/frontend/app/pages/request_detail.py
@@ -1,0 +1,86 @@
+"""
+Vista de detalle de una solicitud de cambio.
+
+Esta vista la comparten varias personas del equipo. La sección
+"Acciones del aprobador" es responsabilidad de Persona 3 (feature de aprobación).
+"""
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from uuid import UUID
+
+import streamlit as st
+
+from app.api_client import ApiClient
+
+st.set_page_config(page_title="Detalle de solicitud", page_icon="📄")
+st.title("📄 Detalle de solicitud")
+
+if "user_id" not in st.session_state:
+    st.warning("Debes iniciar sesión.")
+    st.stop()
+
+user_id: UUID = st.session_state["user_id"]
+client = ApiClient(user_id=user_id)
+
+# ----- Datos de la solicitud (los renderiza el compañero responsable) -----
+st.info(
+    "Aquí va la información completa de la solicitud "
+    "(título, descripción, risk, estado, plan de rollback, historial, etc). "
+    "Implementación a cargo de otra persona del equipo."
+)
+
+st.divider()
+
+# =============================================================================
+# Acciones del aprobador (Persona 3)
+# =============================================================================
+
+st.subheader("Acciones del aprobador")
+
+approval_id_str = st.text_input(
+    "Approval ID asignada a ti para esta solicitud",
+    help="Cuando se conecte el listado real, esto se rellenará automáticamente.",
+)
+
+if approval_id_str:
+    try:
+        approval_id = UUID(approval_id_str)
+    except ValueError:
+        st.error("Approval ID inválido.")
+        st.stop()
+
+    action = st.radio(
+        "¿Qué deseas hacer?",
+        options=["Aprobar", "Rechazar", "Solicitar cambios"],
+        horizontal=True,
+    )
+
+    comment = ""
+    if action in ("Rechazar", "Solicitar cambios"):
+        comment = st.text_area(
+            f"Comentario (obligatorio para {action.lower()})",
+            key="detail_comment",
+        )
+
+    if st.button("Confirmar acción", type="primary"):
+        if action == "Aprobar":
+            ok, msg, _ = client.approve(approval_id)
+        elif action == "Rechazar":
+            if not comment.strip():
+                st.error("El comentario es obligatorio.")
+                st.stop()
+            ok, msg, _ = client.reject(approval_id, comment)
+        else:
+            if not comment.strip():
+                st.error("El comentario es obligatorio.")
+                st.stop()
+            st.info("TODO: endpoint dedicado para solicitar cambios.")
+            st.stop()
+
+        if ok:
+            st.success(msg)
+        else:
+            st.error(msg)

--- a/frontend/pytest.ini
+++ b/frontend/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+testpaths = tests

--- a/frontend/requirements.txt
+++ b/frontend/requirements.txt
@@ -1,0 +1,2 @@
+streamlit
+requests

--- a/frontend/tests/test_api_client.py
+++ b/frontend/tests/test_api_client.py
@@ -1,0 +1,56 @@
+"""Tests del cliente HTTP del frontend."""
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.api_client import ApiClient
+
+
+@patch("app.api_client.requests.post")
+def test_approve_success(mock_post):
+    mock_post.return_value = MagicMock(
+        status_code=200,
+        json=lambda: {"message": "ok", "new_status": "APPROVED"},
+    )
+    client = ApiClient(user_id=uuid4())
+    ok, msg, data = client.approve(uuid4())
+    assert ok is True
+    assert msg == "ok"
+
+
+@patch("app.api_client.requests.post")
+def test_approve_unauthorized(mock_post):
+    mock_post.return_value = MagicMock(
+        status_code=403,
+        json=lambda: {"detail": "No autorizado"},
+    )
+    client = ApiClient(user_id=uuid4())
+    ok, msg, _ = client.approve(uuid4())
+    assert ok is False
+    assert "autorizado" in msg.lower()
+
+
+@patch("app.api_client.requests.post")
+def test_reject_sends_comment(mock_post):
+    mock_post.return_value = MagicMock(
+        status_code=200,
+        json=lambda: {"message": "rechazada"},
+    )
+    client = ApiClient(user_id=uuid4())
+    client.reject(uuid4(), comment="Falta plan de rollback")
+    # Verificar que el comentario viajó en el body
+    _, kwargs = mock_post.call_args
+    assert kwargs["json"]["comment"] == "Falta plan de rollback"
+
+
+@patch("app.api_client.requests.post")
+def test_assign_reviewer(mock_post):
+    mock_post.return_value = MagicMock(
+        status_code=201,
+        json=lambda: {"message": "asignado"},
+    )
+    client = ApiClient(user_id=uuid4())
+    ok, _, _ = client.assign_reviewer(uuid4(), uuid4())
+    assert ok is True


### PR DESCRIPTION
## Descripción
Implementa la interfaz del aprobador en Streamlit: bandeja de pendientes 
y acciones de aprobar / rechazar / solicitar cambios desde el detalle 
de la solicitud.

> ⚠️ Stacked PR: depende de #25 . Base: `feat/approval-api-and-repo`.

## Cambios
- `frontend/app/api_client.py`: cliente HTTP para los endpoints de aprobación
- `frontend/app/pages/approver_inbox.py`: bandeja del aprobador
- `frontend/app/pages/request_detail.py`: acciones del aprobador en el detalle
- `frontend/requirements.txt`: streamlit, requests
- `frontend/tests/test_api_client.py`: tests unitarios del cliente

## Notas para el equipo
- La autenticación es placeholder (`X-User-Id`). Cuando se conecte el login real,
  el `user_id` ya no se ingresará manualmente sino que vendrá de la sesión.
- El listado de pendientes tiene un input manual de Approval ID. Cuando se 
  agregue el endpoint `GET /approvals/me`, se reemplaza por el listado real.
- "Solicitar cambios" tiene un TODO: requiere endpoint dedicado.

## Cómo probar
\`\`\`
cd frontend
pip install -r requirements.txt
streamlit run app/pages/approver_inbox.py
\`\`\`

Tests:
\`\`\`
cd frontend
pytest -v
\`\`\`

Closes #26