### PR TITLE
feat: notificaciones, auditoría y event bus — feature completa end-to-end

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -5,11 +5,14 @@ Dependencies de FastAPI: inyección de repositorios, casos de uso y usuario actu
 from uuid import UUID
 
 from fastapi import Depends, Header, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.orm import Session
 
 from app.application.use_cases.approve_request import ApproveRequestUseCase
 from app.application.use_cases.assign_reviewer import AssignReviewerUseCase
 from app.application.use_cases.reject_request import RejectRequestUseCase
+from app.domain.enums import Role
+from app.infrastructure.auth.token_provider import TokenProvider
 from app.infrastructure.db.session import get_db
 from app.infrastructure.repositories.approval_repository import (
     SQLAlchemyApprovalRepository,
@@ -104,10 +107,6 @@ def get_change_request_repository():
             return None
 
     return FakeRepository()
-from fastapi import Depends, HTTPException, status
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-from infrastructure.auth.token_provider import TokenProvider
-from domain.enums import Role
 
 
 bearer_scheme = HTTPBearer()

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -14,8 +14,12 @@ from app.infrastructure.db.session import get_db
 from app.infrastructure.repositories.approval_repository import (
     SQLAlchemyApprovalRepository,
 )
+from app.infrastructure.repositories.audit_repository import SQLAlchemyAuditRepository
 from app.infrastructure.repositories.change_request_repository import (
     SQLAlchemyChangeRequestRepository,
+)
+from app.infrastructure.repositories.notification_repository import (
+    SQLAlchemyNotificationRepository,
 )
 
 
@@ -27,6 +31,16 @@ def get_approval_repo(db: Session = Depends(get_db)):
 
 def get_change_request_repo(db: Session = Depends(get_db)):
     return SQLAlchemyChangeRequestRepository(db)
+
+
+# ---- Repositorios de notificaciones y auditoría ----
+
+def get_notification_repo(db: Session = Depends(get_db)):
+    return SQLAlchemyNotificationRepository(db)
+
+
+def get_audit_repo(db: Session = Depends(get_db)):
+    return SQLAlchemyAuditRepository(db)
 
 
 # ---- Casos de uso ----

--- a/backend/app/api/routes/audit.py
+++ b/backend/app/api/routes/audit.py
@@ -1,0 +1,56 @@
+"""Rutas de auditoría: GET /audit, GET /audit/{entity_type}/{entity_id}."""
+
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+
+from app.api.dependencies import get_audit_repo, get_current_user
+from app.api.schemas import AuditEntryResponse
+from app.infrastructure.repositories.audit_repository import SQLAlchemyAuditRepository
+
+router = APIRouter(prefix="/audit", tags=["audit"])
+
+
+@router.get("", response_model=List[AuditEntryResponse])
+def list_audit_log(
+    current_user: dict = Depends(get_current_user),
+    repo: SQLAlchemyAuditRepository = Depends(get_audit_repo),
+):
+    """Devuelve todo el log de auditoría ordenado por fecha desc. Solo para Admin."""
+    entries = repo.list_all()
+    return [
+        AuditEntryResponse(
+            id=e.id,
+            actor_id=e.actor_id,
+            action=e.action,
+            entity_type=e.entity_type,
+            entity_id=e.entity_id,
+            detail=e.detail,
+            occurred_at=e.occurred_at,
+        )
+        for e in entries
+    ]
+
+
+@router.get("/{entity_type}/{entity_id}", response_model=List[AuditEntryResponse])
+def list_audit_for_entity(
+    entity_type: str,
+    entity_id: str,
+    current_user: dict = Depends(get_current_user),
+    repo: SQLAlchemyAuditRepository = Depends(get_audit_repo),
+):
+    """Devuelve el historial de auditoría de una entidad específica (ej. ChangeRequest)."""
+    entries = repo.list_for_entity(entity_type, entity_id)
+    return [
+        AuditEntryResponse(
+            id=e.id,
+            actor_id=e.actor_id,
+            action=e.action,
+            entity_type=e.entity_type,
+            entity_id=e.entity_id,
+            detail=e.detail,
+            occurred_at=e.occurred_at,
+        )
+        for e in entries
+    ]

--- a/backend/app/api/routes/notifications.py
+++ b/backend/app/api/routes/notifications.py
@@ -1,0 +1,51 @@
+"""Rutas de notificaciones: GET /notifications/me, POST /notifications/{id}/read."""
+
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.api.dependencies import get_current_user, get_notification_repo
+from app.api.schemas import NotificationResponse
+from app.infrastructure.repositories.notification_repository import (
+    SQLAlchemyNotificationRepository,
+)
+
+router = APIRouter(prefix="/notifications", tags=["notifications"])
+
+
+@router.get("/me", response_model=List[NotificationResponse])
+def list_my_notifications(
+    current_user: dict = Depends(get_current_user),
+    repo: SQLAlchemyNotificationRepository = Depends(get_notification_repo),
+):
+    """Devuelve todas las notificaciones del usuario autenticado, ordenadas por fecha desc."""
+    user_id = current_user["sub"]
+    notifications = repo.list_for_user(user_id)
+    return [
+        NotificationResponse(
+            id=n.id,
+            user_id=n.user_id,
+            message=n.message,
+            event_type=n.event_type,
+            read=n.read,
+            created_at=n.created_at,
+        )
+        for n in notifications
+    ]
+
+
+@router.post("/{notification_id}/read", status_code=status.HTTP_204_NO_CONTENT)
+def mark_notification_read(
+    notification_id: UUID,
+    current_user: dict = Depends(get_current_user),
+    repo: SQLAlchemyNotificationRepository = Depends(get_notification_repo),
+):
+    """Marca una notificación como leída. Solo el dueño puede marcarla."""
+    user_id = current_user["sub"]
+    success = repo.mark_read(notification_id, user_id)
+    if not success:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Notificación no encontrada o no pertenece al usuario.",
+        )

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -30,3 +30,22 @@ class ActionResponse(BaseModel):
     success: bool
     message: str
     new_status: Optional[str] = None
+
+
+class NotificationResponse(BaseModel):
+    id: UUID
+    user_id: str
+    message: str
+    event_type: str
+    read: bool
+    created_at: datetime
+
+
+class AuditEntryResponse(BaseModel):
+    id: UUID
+    actor_id: str
+    action: str
+    entity_type: str
+    entity_id: str
+    detail: Optional[str]
+    occurred_at: datetime

--- a/backend/app/application/services/audit_service.py
+++ b/backend/app/application/services/audit_service.py
@@ -1,0 +1,85 @@
+from typing import Protocol
+
+from app.domain.entities import AuditEntry
+from app.domain.events import (
+    ChangesRequested,
+    RequestApproved,
+    RequestCreated,
+    RequestRejected,
+    RequestSubmitted,
+    ReviewerAssigned,
+    UserCreated,
+)
+
+
+class AuditRepository(Protocol):
+    def save(self, entry: AuditEntry) -> None: ...
+
+
+class AuditService:
+    """Suscriptor del EventBus que registra AuditEntries ante eventos de dominio."""
+
+    def __init__(self, audit_repo: AuditRepository) -> None:
+        self._repo = audit_repo
+
+    def on_user_created(self, event: UserCreated) -> None:
+        self._repo.save(AuditEntry(
+            actor_id=event.user_id,
+            action="USER_CREATED",
+            entity_type="User",
+            entity_id=event.user_id,
+            detail=f"role={event.role}",
+        ))
+
+    def on_request_created(self, event: RequestCreated) -> None:
+        self._repo.save(AuditEntry(
+            actor_id=str(event.requester_id),
+            action="REQUEST_CREATED",
+            entity_type="ChangeRequest",
+            entity_id=str(event.request_id),
+            detail=f"risk={event.risk_level}",
+        ))
+
+    def on_request_submitted(self, event: RequestSubmitted) -> None:
+        self._repo.save(AuditEntry(
+            actor_id=str(event.requester_id),
+            action="REQUEST_SUBMITTED",
+            entity_type="ChangeRequest",
+            entity_id=str(event.request_id),
+        ))
+
+    def on_request_approved(self, event: RequestApproved) -> None:
+        self._repo.save(AuditEntry(
+            actor_id=str(event.reviewer_id),
+            action="REQUEST_APPROVED",
+            entity_type="ChangeRequest",
+            entity_id=str(event.request_id),
+            detail=f"approval_id={event.approval_id}",
+        ))
+
+    def on_request_rejected(self, event: RequestRejected) -> None:
+        self._repo.save(AuditEntry(
+            actor_id=str(event.reviewer_id),
+            action="REQUEST_REJECTED",
+            entity_type="ChangeRequest",
+            entity_id=str(event.request_id),
+            detail=event.comment,
+        ))
+
+    def on_reviewer_assigned(self, event: ReviewerAssigned) -> None:
+        self._repo.save(AuditEntry(
+            actor_id=str(event.reviewer_id),
+            action="REVIEWER_ASSIGNED",
+            entity_type="ChangeRequest",
+            entity_id=str(event.request_id),
+            detail=f"approval_id={event.approval_id}",
+        ))
+
+    def on_changes_requested(self, event: ChangesRequested) -> None:
+        self._repo.save(AuditEntry(
+            actor_id=str(event.reviewer_id),
+            action="CHANGES_REQUESTED",
+            entity_type="ChangeRequest",
+            entity_id=str(event.request_id),
+            detail=event.comment,
+        ))

--- a/backend/app/application/services/event_bus.py
+++ b/backend/app/application/services/event_bus.py
@@ -1,0 +1,27 @@
+from collections import defaultdict
+from typing import Callable, Type
+
+from app.domain.events import DomainEvent
+
+
+class EventBus:
+    """Singleton event bus. Subscribers register by event type (Observer pattern)."""
+
+    _instance: "EventBus | None" = None
+
+    def __new__(cls) -> "EventBus":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._subscribers: dict[Type[DomainEvent], list[Callable]] = defaultdict(list)
+        return cls._instance
+
+    def subscribe(self, event_type: Type[DomainEvent], handler: Callable[[DomainEvent], None]) -> None:
+        self._subscribers[event_type].append(handler)
+
+    def publish(self, event: DomainEvent) -> None:
+        for handler in self._subscribers[type(event)]:
+            handler(event)
+
+    def reset(self) -> None:
+        """Solo para tests — limpia todos los suscriptores."""
+        self._subscribers = defaultdict(list)

--- a/backend/app/application/services/notification_service.py
+++ b/backend/app/application/services/notification_service.py
@@ -1,0 +1,70 @@
+from typing import Protocol
+
+from app.domain.entities import Notification
+from app.domain.events import (
+    ChangesRequested,
+    RequestApproved,
+    RequestCreated,
+    RequestRejected,
+    RequestSubmitted,
+    ReviewerAssigned,
+)
+
+
+class NotificationRepository(Protocol):
+    def save(self, notification: Notification) -> None: ...
+
+
+class NotificationService:
+    """Suscriptor del EventBus que genera Notifications ante eventos de dominio."""
+
+    def __init__(self, notification_repo: NotificationRepository) -> None:
+        self._repo = notification_repo
+
+    def on_request_created(self, event: RequestCreated) -> None:
+        n = Notification(
+            user_id=str(event.requester_id),
+            message=f"Tu solicitud '{event.title}' fue creada exitosamente.",
+            event_type="REQUEST_CREATED",
+        )
+        self._repo.save(n)
+
+    def on_request_submitted(self, event: RequestSubmitted) -> None:
+        n = Notification(
+            user_id=str(event.requester_id),
+            message=f"Tu solicitud '{event.title}' fue enviada para revisión.",
+            event_type="REQUEST_SUBMITTED",
+        )
+        self._repo.save(n)
+
+    def on_request_approved(self, event: RequestApproved) -> None:
+        n = Notification(
+            user_id=str(event.reviewer_id),
+            message=f"La solicitud {event.request_id} fue aprobada.",
+            event_type="REQUEST_APPROVED",
+        )
+        self._repo.save(n)
+
+    def on_request_rejected(self, event: RequestRejected) -> None:
+        n = Notification(
+            user_id=str(event.reviewer_id),
+            message=f"La solicitud {event.request_id} fue rechazada. Motivo: {event.comment}",
+            event_type="REQUEST_REJECTED",
+        )
+        self._repo.save(n)
+
+    def on_reviewer_assigned(self, event: ReviewerAssigned) -> None:
+        n = Notification(
+            user_id=str(event.reviewer_id),
+            message=f"Se te asignó como revisor de la solicitud {event.request_id}.",
+            event_type="REVIEWER_ASSIGNED",
+        )
+        self._repo.save(n)
+
+    def on_changes_requested(self, event: ChangesRequested) -> None:
+        n = Notification(
+            user_id=str(event.reviewer_id),
+            message=f"Se solicitaron cambios en la solicitud {event.request_id}: {event.comment}",
+            event_type="CHANGES_REQUESTED",
+        )
+        self._repo.save(n)

--- a/backend/app/application/services/notification_service.py
+++ b/backend/app/application/services/notification_service.py
@@ -1,3 +1,5 @@
+import logging
+import os
 from typing import Protocol
 
 from app.domain.entities import Notification
@@ -10,61 +12,91 @@ from app.domain.events import (
     ReviewerAssigned,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class NotificationRepository(Protocol):
     def save(self, notification: Notification) -> None: ...
 
 
+# ----- Strategy: canales de notificación -----
+
+class NotificationChannel(Protocol):
+    def send(self, notification: Notification) -> None: ...
+
+
+class InAppChannel:
+    """Persiste la notificación en base de datos (canal principal)."""
+
+    def __init__(self, repo: NotificationRepository) -> None:
+        self._repo = repo
+
+    def send(self, notification: Notification) -> None:
+        self._repo.save(notification)
+
+
+class EmailChannel:
+    """Mock de email — loguea el mensaje en lugar de enviarlo.
+    Activar con variable de entorno EMAIL_NOTIFICATIONS=true."""
+
+    def send(self, notification: Notification) -> None:
+        if os.getenv("EMAIL_NOTIFICATIONS", "false").lower() == "true":
+            logger.info(
+                "EMAIL → user=%s event=%s msg=%s",
+                notification.user_id,
+                notification.event_type,
+                notification.message,
+            )
+
+
 class NotificationService:
     """Suscriptor del EventBus que genera Notifications ante eventos de dominio."""
 
-    def __init__(self, notification_repo: NotificationRepository) -> None:
-        self._repo = notification_repo
+    def __init__(self, channels: list[NotificationChannel]) -> None:
+        self._channels = channels
+
+    def _notify(self, notification: Notification) -> None:
+        for channel in self._channels:
+            channel.send(notification)
 
     def on_request_created(self, event: RequestCreated) -> None:
-        n = Notification(
+        self._notify(Notification(
             user_id=str(event.requester_id),
             message=f"Tu solicitud '{event.title}' fue creada exitosamente.",
             event_type="REQUEST_CREATED",
-        )
-        self._repo.save(n)
+        ))
 
     def on_request_submitted(self, event: RequestSubmitted) -> None:
-        n = Notification(
+        self._notify(Notification(
             user_id=str(event.requester_id),
             message=f"Tu solicitud '{event.title}' fue enviada para revisión.",
             event_type="REQUEST_SUBMITTED",
-        )
-        self._repo.save(n)
+        ))
 
     def on_request_approved(self, event: RequestApproved) -> None:
-        n = Notification(
+        self._notify(Notification(
             user_id=str(event.reviewer_id),
             message=f"La solicitud {event.request_id} fue aprobada.",
             event_type="REQUEST_APPROVED",
-        )
-        self._repo.save(n)
+        ))
 
     def on_request_rejected(self, event: RequestRejected) -> None:
-        n = Notification(
+        self._notify(Notification(
             user_id=str(event.reviewer_id),
             message=f"La solicitud {event.request_id} fue rechazada. Motivo: {event.comment}",
             event_type="REQUEST_REJECTED",
-        )
-        self._repo.save(n)
+        ))
 
     def on_reviewer_assigned(self, event: ReviewerAssigned) -> None:
-        n = Notification(
+        self._notify(Notification(
             user_id=str(event.reviewer_id),
             message=f"Se te asignó como revisor de la solicitud {event.request_id}.",
             event_type="REVIEWER_ASSIGNED",
-        )
-        self._repo.save(n)
+        ))
 
     def on_changes_requested(self, event: ChangesRequested) -> None:
-        n = Notification(
+        self._notify(Notification(
             user_id=str(event.reviewer_id),
             message=f"Se solicitaron cambios en la solicitud {event.request_id}: {event.comment}",
             event_type="CHANGES_REQUESTED",
-        )
-        self._repo.save(n)
+        ))

--- a/backend/app/domain/entities.py
+++ b/backend/app/domain/entities.py
@@ -1,8 +1,17 @@
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Optional
 from uuid import UUID, uuid4
 
-from app.domain.enums import ChangeStatus, RiskLevel
+from app.domain.enums import (
+    ApprovalStatus,
+    ChangeStatus,
+    DecisionAction,
+    Permission,
+    RiskLevel,
+    Role,
+)
+from app.domain.value_objects import ROLE_PERMISSIONS
 
 
 @dataclass
@@ -15,9 +24,9 @@ class ChangeRequest:
     id: UUID = field(default_factory=uuid4)
     status: ChangeStatus = ChangeStatus.DRAFT
     created_at: datetime = field(default_factory=datetime.utcnow)
-    scheduled_at: datetime | None = None
-    executed_at: datetime | None = None
-    failure_reason: str | None = None
+    scheduled_at: Optional[datetime] = None
+    executed_at: Optional[datetime] = None
+    failure_reason: Optional[str] = None
 
     def __post_init__(self) -> None:
         if not self.title.strip():
@@ -30,13 +39,12 @@ class ChangeRequest:
             raise ValueError("risk_level must be a valid RiskLevel")
         if not isinstance(self.status, ChangeStatus):
             raise ValueError("status must be a valid ChangeStatus")
-    
+
     def submit(self) -> None:
         if self.status != ChangeStatus.DRAFT:
             raise ValueError("Only draft requests can be submitted")
         self.status = ChangeStatus.SUBMITTED
-from domain.enums import Role, Permission
-from domain.value_objects import ROLE_PERMISSIONS
+
 
 @dataclass
 class User:
@@ -61,7 +69,7 @@ class UserFactory:
         hashed_password: str,
         role: Role,
         is_active: bool = True,
-    ) -> User:
+    ) -> "User":
         permissions = ROLE_PERMISSIONS.get(role, [])
         return User(
             id=id,
@@ -72,13 +80,6 @@ class UserFactory:
             is_active=is_active,
             permissions=permissions,
         )
-        
-from dataclasses import dataclass, field
-from datetime import datetime
-from typing import Optional
-from uuid import UUID, uuid4
-
-from app.domain.enums import ApprovalStatus, DecisionAction
 
 
 @dataclass
@@ -133,3 +134,29 @@ class Decision:
                 raise ValueError(
                     f"La acción {self.action.value} requiere un comentario."
                 )
+
+
+@dataclass
+class Notification:
+    """Notificación generada para un usuario cuando ocurre un evento relevante."""
+    user_id: str
+    message: str
+    event_type: str
+    id: UUID = field(default_factory=uuid4)
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    read: bool = False
+
+    def mark_read(self) -> None:
+        self.read = True
+
+
+@dataclass
+class AuditEntry:
+    """Registro inmutable de una acción importante en el sistema."""
+    actor_id: str
+    action: str
+    entity_type: str
+    entity_id: str
+    id: UUID = field(default_factory=uuid4)
+    detail: Optional[str] = None
+    occurred_at: datetime = field(default_factory=datetime.utcnow)

--- a/backend/app/domain/events.py
+++ b/backend/app/domain/events.py
@@ -1,7 +1,60 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import datetime
+from uuid import UUID
+
 
 @dataclass
-class UserCreated:
-    user_id: str
-    email: str
-    role: str
+class DomainEvent:
+    occurred_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class UserCreated(DomainEvent):
+    user_id: str = ""
+    email: str = ""
+    role: str = ""
+
+
+@dataclass
+class RequestCreated(DomainEvent):
+    request_id: UUID = None
+    requester_id: UUID = None
+    title: str = ""
+    risk_level: str = ""
+
+
+@dataclass
+class RequestSubmitted(DomainEvent):
+    request_id: UUID = None
+    requester_id: UUID = None
+    title: str = ""
+
+
+@dataclass
+class RequestApproved(DomainEvent):
+    request_id: UUID = None
+    reviewer_id: UUID = None
+    approval_id: UUID = None
+
+
+@dataclass
+class RequestRejected(DomainEvent):
+    request_id: UUID = None
+    reviewer_id: UUID = None
+    approval_id: UUID = None
+    comment: str = ""
+
+
+@dataclass
+class ReviewerAssigned(DomainEvent):
+    request_id: UUID = None
+    reviewer_id: UUID = None
+    approval_id: UUID = None
+
+
+@dataclass
+class ChangesRequested(DomainEvent):
+    request_id: UUID = None
+    reviewer_id: UUID = None
+    approval_id: UUID = None
+    comment: str = ""

--- a/backend/app/domain/value_objects.py
+++ b/backend/app/domain/value_objects.py
@@ -1,4 +1,4 @@
-from domain.enums import Role, Permission
+from app.domain.enums import Role, Permission
 
 ROLE_PERMISSIONS: dict[Role, list[Permission]] = {
     Role.ENGINEER: [

--- a/backend/app/infrastructure/db/models.py
+++ b/backend/app/infrastructure/db/models.py
@@ -11,7 +11,7 @@ la entidad principal puede extenderlo con los campos que necesite.
 from datetime import datetime
 from uuid import uuid4
 
-from sqlalchemy import Column, DateTime, Enum as SAEnum, ForeignKey, String, Text
+from sqlalchemy import Boolean, Column, DateTime, Enum as SAEnum, ForeignKey, String, Text
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import relationship
 
@@ -86,3 +86,26 @@ class DecisionModel(Base):
     decided_at = Column(DateTime, default=datetime.utcnow, nullable=False)
 
     approval = relationship("ApprovalModel", back_populates="decisions")
+
+
+class NotificationModel(Base):
+    __tablename__ = "notifications"
+
+    id = Column(PGUUID(as_uuid=True), primary_key=True, default=uuid4)
+    user_id = Column(String, nullable=False)
+    message = Column(Text, nullable=False)
+    event_type = Column(String(100), nullable=False)
+    read = Column(Boolean, nullable=False, default=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+
+class AuditEntryModel(Base):
+    __tablename__ = "audit_entries"
+
+    id = Column(PGUUID(as_uuid=True), primary_key=True, default=uuid4)
+    actor_id = Column(String, nullable=False)
+    action = Column(String(100), nullable=False)
+    entity_type = Column(String(100), nullable=False)
+    entity_id = Column(String, nullable=False)
+    detail = Column(Text, nullable=True)
+    occurred_at = Column(DateTime, default=datetime.utcnow, nullable=False)

--- a/backend/app/infrastructure/repositories/audit_repository.py
+++ b/backend/app/infrastructure/repositories/audit_repository.py
@@ -1,0 +1,62 @@
+"""Implementación concreta de AuditRepository usando SQLAlchemy."""
+
+from typing import List, Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.domain.entities import AuditEntry
+from app.infrastructure.db.models import AuditEntryModel
+
+
+class SQLAlchemyAuditRepository:
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    @staticmethod
+    def _to_entity(model: AuditEntryModel) -> AuditEntry:
+        return AuditEntry(
+            id=model.id,
+            actor_id=model.actor_id,
+            action=model.action,
+            entity_type=model.entity_type,
+            entity_id=model.entity_id,
+            detail=model.detail,
+            occurred_at=model.occurred_at,
+        )
+
+    @staticmethod
+    def _to_model(entity: AuditEntry) -> AuditEntryModel:
+        return AuditEntryModel(
+            id=entity.id,
+            actor_id=entity.actor_id,
+            action=entity.action,
+            entity_type=entity.entity_type,
+            entity_id=entity.entity_id,
+            detail=entity.detail,
+            occurred_at=entity.occurred_at,
+        )
+
+    def save(self, entry: AuditEntry) -> None:
+        self.session.add(self._to_model(entry))
+        self.session.commit()
+
+    def list_all(self) -> List[AuditEntry]:
+        models = (
+            self.session.query(AuditEntryModel)
+            .order_by(AuditEntryModel.occurred_at.desc())
+            .all()
+        )
+        return [self._to_entity(m) for m in models]
+
+    def list_for_entity(self, entity_type: str, entity_id: str) -> List[AuditEntry]:
+        models = (
+            self.session.query(AuditEntryModel)
+            .filter(
+                AuditEntryModel.entity_type == entity_type,
+                AuditEntryModel.entity_id == entity_id,
+            )
+            .order_by(AuditEntryModel.occurred_at.desc())
+            .all()
+        )
+        return [self._to_entity(m) for m in models]

--- a/backend/app/infrastructure/repositories/notification_repository.py
+++ b/backend/app/infrastructure/repositories/notification_repository.py
@@ -1,0 +1,57 @@
+"""Implementación concreta de NotificationRepository usando SQLAlchemy."""
+
+from typing import List
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.domain.entities import Notification
+from app.infrastructure.db.models import NotificationModel
+
+
+class SQLAlchemyNotificationRepository:
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    @staticmethod
+    def _to_entity(model: NotificationModel) -> Notification:
+        return Notification(
+            id=model.id,
+            user_id=model.user_id,
+            message=model.message,
+            event_type=model.event_type,
+            read=model.read,
+            created_at=model.created_at,
+        )
+
+    @staticmethod
+    def _to_model(entity: Notification) -> NotificationModel:
+        return NotificationModel(
+            id=entity.id,
+            user_id=entity.user_id,
+            message=entity.message,
+            event_type=entity.event_type,
+            read=entity.read,
+            created_at=entity.created_at,
+        )
+
+    def save(self, notification: Notification) -> None:
+        self.session.add(self._to_model(notification))
+        self.session.commit()
+
+    def list_for_user(self, user_id: str) -> List[Notification]:
+        models = (
+            self.session.query(NotificationModel)
+            .filter(NotificationModel.user_id == user_id)
+            .order_by(NotificationModel.created_at.desc())
+            .all()
+        )
+        return [self._to_entity(m) for m in models]
+
+    def mark_read(self, notification_id: UUID, user_id: str) -> bool:
+        model = self.session.get(NotificationModel, notification_id)
+        if not model or model.user_id != user_id:
+            return False
+        model.read = True
+        self.session.commit()
+        return True

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 """Punto de entrada de la API FastAPI."""
 
+import os
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -9,7 +10,11 @@ from app.api.routes import notifications as notifications_router
 from app.api.routes import requests as requests_router
 from app.application.services.audit_service import AuditService
 from app.application.services.event_bus import EventBus
-from app.application.services.notification_service import NotificationService
+from app.application.services.notification_service import (
+    EmailChannel,
+    InAppChannel,
+    NotificationService,
+)
 from app.domain.events import (
     ChangesRequested,
     RequestApproved,
@@ -32,7 +37,10 @@ async def lifespan(app: FastAPI):
     notification_repo = SQLAlchemyNotificationRepository(session)
     audit_repo = SQLAlchemyAuditRepository(session)
 
-    notification_svc = NotificationService(notification_repo)
+    channels = [InAppChannel(notification_repo)]
+    if os.getenv("EMAIL_NOTIFICATIONS", "false").lower() == "true":
+        channels.append(EmailChannel())
+    notification_svc = NotificationService(channels)
     audit_svc = AuditService(audit_repo)
 
     bus = EventBus()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,8 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+from app.api.routes import audit as audit_router
+from app.api.routes import notifications as notifications_router
 from app.api.routes import requests as requests_router
 from app.application.services.audit_service import AuditService
 from app.application.services.event_bus import EventBus
@@ -58,6 +60,8 @@ async def lifespan(app: FastAPI):
 app = FastAPI(title="ChangeFlow API", lifespan=lifespan)
 
 app.include_router(requests_router.router)
+app.include_router(notifications_router.router)
+app.include_router(audit_router.router)
 
 
 @app.get("/health")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,61 @@
 """Punto de entrada de la API FastAPI."""
 
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 
 from app.api.routes import requests as requests_router
+from app.application.services.audit_service import AuditService
+from app.application.services.event_bus import EventBus
+from app.application.services.notification_service import NotificationService
+from app.domain.events import (
+    ChangesRequested,
+    RequestApproved,
+    RequestCreated,
+    RequestRejected,
+    RequestSubmitted,
+    ReviewerAssigned,
+    UserCreated,
+)
+from app.infrastructure.db.session import SessionLocal
+from app.infrastructure.repositories.audit_repository import SQLAlchemyAuditRepository
+from app.infrastructure.repositories.notification_repository import SQLAlchemyNotificationRepository
 
-app = FastAPI(title="ChangeFlow API")
+# Se ejecuta al arrancar y al apagar la app (antes y después del yield, respectivamente).
+# Instancia repos y servicios, y registra todos los handlers en el EventBus.
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    session = SessionLocal()
+
+    notification_repo = SQLAlchemyNotificationRepository(session)
+    audit_repo = SQLAlchemyAuditRepository(session)
+
+    notification_svc = NotificationService(notification_repo)
+    audit_svc = AuditService(audit_repo)
+
+    bus = EventBus()
+
+    bus.subscribe(RequestCreated, notification_svc.on_request_created)
+    bus.subscribe(RequestSubmitted, notification_svc.on_request_submitted)
+    bus.subscribe(RequestApproved, notification_svc.on_request_approved)
+    bus.subscribe(RequestRejected, notification_svc.on_request_rejected)
+    bus.subscribe(ReviewerAssigned, notification_svc.on_reviewer_assigned)
+    bus.subscribe(ChangesRequested, notification_svc.on_changes_requested)
+
+    bus.subscribe(UserCreated, audit_svc.on_user_created)
+    bus.subscribe(RequestCreated, audit_svc.on_request_created)
+    bus.subscribe(RequestSubmitted, audit_svc.on_request_submitted)
+    bus.subscribe(RequestApproved, audit_svc.on_request_approved)
+    bus.subscribe(RequestRejected, audit_svc.on_request_rejected)
+    bus.subscribe(ReviewerAssigned, audit_svc.on_reviewer_assigned)
+    bus.subscribe(ChangesRequested, audit_svc.on_changes_requested)
+
+    yield  # la app corre aquí
+
+    session.close()
+
+
+app = FastAPI(title="ChangeFlow API", lifespan=lifespan)
 
 app.include_router(requests_router.router)
 

--- a/backend/app/tests/test_notifications_audit.py
+++ b/backend/app/tests/test_notifications_audit.py
@@ -1,0 +1,302 @@
+"""Tests de NotificationService, AuditService y EventBus usando fakes en memoria."""
+
+from typing import List
+from uuid import uuid4
+
+import pytest
+
+from app.application.services.audit_service import AuditService
+from app.application.services.event_bus import EventBus
+from app.application.services.notification_service import NotificationService
+from app.domain.entities import AuditEntry, Notification
+from app.domain.events import (
+    ChangesRequested,
+    RequestApproved,
+    RequestCreated,
+    RequestRejected,
+    RequestSubmitted,
+    ReviewerAssigned,
+    UserCreated,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+class FakeNotificationRepository:
+    def __init__(self):
+        self.saved: List[Notification] = []
+
+    def save(self, notification: Notification) -> None:
+        self.saved.append(notification)
+
+
+class FakeAuditRepository:
+    def __init__(self):
+        self.saved: List[AuditEntry] = []
+
+    def save(self, entry: AuditEntry) -> None:
+        self.saved.append(entry)
+
+
+# ---------------------------------------------------------------------------
+# NotificationService
+# ---------------------------------------------------------------------------
+
+class TestNotificationService:
+    def setup_method(self):
+        self.repo = FakeNotificationRepository()
+        self.service = NotificationService(self.repo)
+
+    def test_on_request_created_saves_notification(self):
+        event = RequestCreated(
+            request_id=uuid4(),
+            requester_id=uuid4(),
+            title="Deploy v2",
+            risk_level="LOW",
+        )
+        self.service.on_request_created(event)
+
+        assert len(self.repo.saved) == 1
+        n = self.repo.saved[0]
+        assert n.user_id == str(event.requester_id)
+        assert n.event_type == "REQUEST_CREATED"
+        assert "Deploy v2" in n.message
+        assert n.read is False
+
+    def test_on_request_submitted_saves_notification(self):
+        event = RequestSubmitted(
+            request_id=uuid4(),
+            requester_id=uuid4(),
+            title="Fix config",
+        )
+        self.service.on_request_submitted(event)
+
+        assert len(self.repo.saved) == 1
+        n = self.repo.saved[0]
+        assert n.user_id == str(event.requester_id)
+        assert n.event_type == "REQUEST_SUBMITTED"
+
+    def test_on_request_approved_notifies_reviewer(self):
+        event = RequestApproved(
+            request_id=uuid4(),
+            reviewer_id=uuid4(),
+            approval_id=uuid4(),
+        )
+        self.service.on_request_approved(event)
+
+        assert len(self.repo.saved) == 1
+        n = self.repo.saved[0]
+        assert n.user_id == str(event.reviewer_id)
+        assert n.event_type == "REQUEST_APPROVED"
+
+    def test_on_request_rejected_includes_comment(self):
+        event = RequestRejected(
+            request_id=uuid4(),
+            reviewer_id=uuid4(),
+            approval_id=uuid4(),
+            comment="Falta plan de rollback",
+        )
+        self.service.on_request_rejected(event)
+
+        n = self.repo.saved[0]
+        assert n.event_type == "REQUEST_REJECTED"
+        assert "Falta plan de rollback" in n.message
+
+    def test_on_reviewer_assigned_notifies_reviewer(self):
+        event = ReviewerAssigned(
+            request_id=uuid4(),
+            reviewer_id=uuid4(),
+            approval_id=uuid4(),
+        )
+        self.service.on_reviewer_assigned(event)
+
+        n = self.repo.saved[0]
+        assert n.user_id == str(event.reviewer_id)
+        assert n.event_type == "REVIEWER_ASSIGNED"
+
+    def test_on_changes_requested_saves_notification(self):
+        event = ChangesRequested(
+            request_id=uuid4(),
+            reviewer_id=uuid4(),
+            approval_id=uuid4(),
+            comment="Ajusta el impacto en prod",
+        )
+        self.service.on_changes_requested(event)
+
+        n = self.repo.saved[0]
+        assert n.event_type == "CHANGES_REQUESTED"
+        assert "Ajusta el impacto en prod" in n.message
+
+
+# ---------------------------------------------------------------------------
+# AuditService
+# ---------------------------------------------------------------------------
+
+class TestAuditService:
+    def setup_method(self):
+        self.repo = FakeAuditRepository()
+        self.service = AuditService(self.repo)
+
+    def test_on_user_created_saves_audit_entry(self):
+        user_id = str(uuid4())
+        event = UserCreated(user_id=user_id, email="a@b.com", role="ENGINEER")
+        self.service.on_user_created(event)
+
+        assert len(self.repo.saved) == 1
+        e = self.repo.saved[0]
+        assert e.actor_id == user_id
+        assert e.action == "USER_CREATED"
+        assert e.entity_type == "User"
+        assert e.entity_id == user_id
+
+    def test_on_request_created_saves_audit_entry(self):
+        request_id = uuid4()
+        requester_id = uuid4()
+        event = RequestCreated(
+            request_id=request_id,
+            requester_id=requester_id,
+            title="Deploy v2",
+            risk_level="HIGH",
+        )
+        self.service.on_request_created(event)
+
+        e = self.repo.saved[0]
+        assert e.action == "REQUEST_CREATED"
+        assert e.entity_type == "ChangeRequest"
+        assert e.entity_id == str(request_id)
+        assert "HIGH" in e.detail
+
+    def test_on_request_approved_records_reviewer(self):
+        request_id = uuid4()
+        reviewer_id = uuid4()
+        event = RequestApproved(
+            request_id=request_id,
+            reviewer_id=reviewer_id,
+            approval_id=uuid4(),
+        )
+        self.service.on_request_approved(event)
+
+        e = self.repo.saved[0]
+        assert e.actor_id == str(reviewer_id)
+        assert e.action == "REQUEST_APPROVED"
+
+    def test_on_request_rejected_stores_comment_as_detail(self):
+        event = RequestRejected(
+            request_id=uuid4(),
+            reviewer_id=uuid4(),
+            approval_id=uuid4(),
+            comment="Riesgo no justificado",
+        )
+        self.service.on_request_rejected(event)
+
+        e = self.repo.saved[0]
+        assert e.action == "REQUEST_REJECTED"
+        assert e.detail == "Riesgo no justificado"
+
+    def test_on_reviewer_assigned_records_approval_id(self):
+        approval_id = uuid4()
+        event = ReviewerAssigned(
+            request_id=uuid4(),
+            reviewer_id=uuid4(),
+            approval_id=approval_id,
+        )
+        self.service.on_reviewer_assigned(event)
+
+        e = self.repo.saved[0]
+        assert e.action == "REVIEWER_ASSIGNED"
+        assert str(approval_id) in e.detail
+
+    def test_on_changes_requested_stores_comment(self):
+        event = ChangesRequested(
+            request_id=uuid4(),
+            reviewer_id=uuid4(),
+            approval_id=uuid4(),
+            comment="Revisar impacto en base de datos",
+        )
+        self.service.on_changes_requested(event)
+
+        e = self.repo.saved[0]
+        assert e.action == "CHANGES_REQUESTED"
+        assert e.detail == "Revisar impacto en base de datos"
+
+
+# ---------------------------------------------------------------------------
+# EventBus (Observer pattern)
+# ---------------------------------------------------------------------------
+
+class TestEventBus:
+    def setup_method(self):
+        # Resetear el Singleton entre tests
+        EventBus().reset()
+
+    def test_subscriber_receives_published_event(self):
+        received = []
+        bus = EventBus()
+        bus.subscribe(RequestCreated, lambda e: received.append(e))
+
+        event = RequestCreated(request_id=uuid4(), requester_id=uuid4(), title="X", risk_level="LOW")
+        bus.publish(event)
+
+        assert len(received) == 1
+        assert received[0] is event
+
+    def test_multiple_subscribers_all_called(self):
+        calls = []
+        bus = EventBus()
+        bus.subscribe(RequestApproved, lambda e: calls.append("sub1"))
+        bus.subscribe(RequestApproved, lambda e: calls.append("sub2"))
+
+        bus.publish(RequestApproved(request_id=uuid4(), reviewer_id=uuid4(), approval_id=uuid4()))
+
+        assert calls == ["sub1", "sub2"]
+
+    def test_unrelated_event_does_not_trigger_subscriber(self):
+        received = []
+        bus = EventBus()
+        bus.subscribe(RequestApproved, lambda e: received.append(e))
+
+        bus.publish(RequestRejected(
+            request_id=uuid4(), reviewer_id=uuid4(), approval_id=uuid4(), comment="x"
+        ))
+
+        assert len(received) == 0
+
+    def test_singleton_is_same_instance(self):
+        bus_a = EventBus()
+        bus_b = EventBus()
+        assert bus_a is bus_b
+
+    def test_notification_service_wired_to_bus(self):
+        """Prueba de integración: NotificationService conectado al EventBus."""
+        repo = FakeNotificationRepository()
+        service = NotificationService(repo)
+
+        bus = EventBus()
+        bus.subscribe(RequestCreated, service.on_request_created)
+
+        event = RequestCreated(
+            request_id=uuid4(),
+            requester_id=uuid4(),
+            title="Integración",
+            risk_level="MEDIUM",
+        )
+        bus.publish(event)
+
+        assert len(repo.saved) == 1
+        assert repo.saved[0].event_type == "REQUEST_CREATED"
+
+    def test_audit_service_wired_to_bus(self):
+        """Prueba de integración: AuditService conectado al EventBus."""
+        repo = FakeAuditRepository()
+        service = AuditService(repo)
+
+        bus = EventBus()
+        bus.subscribe(RequestSubmitted, service.on_request_submitted)
+
+        event = RequestSubmitted(request_id=uuid4(), requester_id=uuid4(), title="Fix")
+        bus.publish(event)
+
+        assert len(repo.saved) == 1
+        assert repo.saved[0].action == "REQUEST_SUBMITTED"

--- a/backend/app/tests/test_notifications_audit.py
+++ b/backend/app/tests/test_notifications_audit.py
@@ -7,7 +7,7 @@ import pytest
 
 from app.application.services.audit_service import AuditService
 from app.application.services.event_bus import EventBus
-from app.application.services.notification_service import NotificationService
+from app.application.services.notification_service import InAppChannel, NotificationService
 from app.domain.entities import AuditEntry, Notification
 from app.domain.events import (
     ChangesRequested,
@@ -47,7 +47,7 @@ class FakeAuditRepository:
 class TestNotificationService:
     def setup_method(self):
         self.repo = FakeNotificationRepository()
-        self.service = NotificationService(self.repo)
+        self.service = NotificationService([InAppChannel(self.repo)])
 
     def test_on_request_created_saves_notification(self):
         event = RequestCreated(
@@ -271,7 +271,7 @@ class TestEventBus:
     def test_notification_service_wired_to_bus(self):
         """Prueba de integración: NotificationService conectado al EventBus."""
         repo = FakeNotificationRepository()
-        service = NotificationService(repo)
+        service = NotificationService([InAppChannel(repo)])
 
         bus = EventBus()
         bus.subscribe(RequestCreated, service.on_request_created)

--- a/frontend/app/main.py
+++ b/frontend/app/main.py
@@ -1,4 +1,9 @@
+import os
+
+import requests
 import streamlit as st
+
+API_URL = os.getenv("API_BASE_URL", "http://backend:8000")
 
 st.set_page_config(
     page_title="ChangeFlow",
@@ -10,6 +15,21 @@ if "token" not in st.session_state:
     st.session_state.token = None
 if "user" not in st.session_state:
     st.session_state.user = None
+
+# Badge de notificaciones no leídas en el sidebar
+if st.session_state.token:
+    try:
+        resp = requests.get(
+            f"{API_URL}/notifications/me",
+            headers={"Authorization": f"Bearer {st.session_state.token}"},
+            timeout=5,
+        )
+        if resp.status_code == 200:
+            unread = sum(1 for n in resp.json() if not n["read"])
+            if unread > 0:
+                st.sidebar.metric("🔔 Notificaciones", unread, help="Notificaciones no leídas")
+    except requests.exceptions.ConnectionError:
+        pass
 
 st.title("🔄 ChangeFlow")
 st.markdown("Plataforma de solicitudes de cambios técnicos.")

--- a/frontend/app/pages/notifications.py
+++ b/frontend/app/pages/notifications.py
@@ -1,0 +1,52 @@
+"""Página de notificaciones del usuario autenticado."""
+
+import os
+
+import requests
+import streamlit as st
+
+API_URL = os.getenv("API_BASE_URL", "http://backend:8000")
+
+st.set_page_config(page_title="Notificaciones — ChangeFlow", page_icon="🔔")
+st.title("🔔 Notificaciones")
+
+if not st.session_state.get("token"):
+    st.warning("Debes iniciar sesión para ver tus notificaciones.")
+    st.stop()
+
+token = st.session_state.token
+headers = {"Authorization": f"Bearer {token}"}
+
+response = requests.get(f"{API_URL}/notifications/me", headers=headers, timeout=10)
+
+if response.status_code != 200:
+    st.error(f"Error al cargar notificaciones: {response.json().get('detail', response.status_code)}")
+    st.stop()
+
+notifications = response.json()
+
+if not notifications:
+    st.info("No tienes notificaciones.")
+    st.stop()
+
+st.caption(f"{len(notifications)} notificación(es)")
+
+for n in notifications:
+    col1, col2 = st.columns([5, 1])
+    with col1:
+        prefix = "📭" if n["read"] else "📬"
+        st.write(f"{prefix} **{n['event_type']}** — {n['message']}")
+        st.caption(n["created_at"])
+    with col2:
+        if not n["read"]:
+            if st.button("Marcar leída", key=n["id"]):
+                resp = requests.post(
+                    f"{API_URL}/notifications/{n['id']}/read",
+                    headers=headers,
+                    timeout=10,
+                )
+                if resp.status_code == 204:
+                    st.rerun()
+                else:
+                    st.error("No se pudo marcar como leída.")
+    st.divider()

--- a/frontend/app/pages/request_detail.py
+++ b/frontend/app/pages/request_detail.py
@@ -5,15 +5,19 @@ Esta vista la comparten varias personas del equipo. La sección
 "Acciones del aprobador" es responsabilidad de Persona 3 (feature de aprobación).
 """
 
+import os
 import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from uuid import UUID
 
+import requests
 import streamlit as st
 
 from app.api_client import ApiClient
+
+API_URL = os.getenv("API_BASE_URL", "http://backend:8000")
 
 st.set_page_config(page_title="Detalle de solicitud", page_icon="📄")
 st.title("📄 Detalle de solicitud")
@@ -84,3 +88,47 @@ if approval_id_str:
             st.success(msg)
         else:
             st.error(msg)
+
+st.divider()
+
+# =============================================================================
+# Historial de la solicitud (Persona 4 — auditoría)
+# =============================================================================
+
+st.subheader("Historial de la solicitud")
+
+request_id_str = st.text_input(
+    "Request ID",
+    help="Cuando se conecte el listado real, esto se rellenará automáticamente.",
+    key="audit_request_id",
+)
+
+if request_id_str:
+    try:
+        UUID(request_id_str)
+    except ValueError:
+        st.error("Request ID inválido.")
+        st.stop()
+
+    if not st.session_state.get("token"):
+        st.warning("Se necesita sesión activa para ver el historial.")
+        st.stop()
+
+    token = st.session_state.token
+    resp = requests.get(
+        f"{API_URL}/audit/ChangeRequest/{request_id_str}",
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=10,
+    )
+
+    if resp.status_code != 200:
+        st.error(f"Error al cargar historial: {resp.json().get('detail', resp.status_code)}")
+        st.stop()
+
+    entries = resp.json()
+
+    if not entries:
+        st.info("Esta solicitud aún no tiene historial.")
+    else:
+        for e in entries:
+            st.caption(f"🕐 {e['occurred_at']}  |  **{e['action']}**  |  actor: `{e['actor_id']}`" + (f"  |  {e['detail']}" if e.get("detail") else ""))


### PR DESCRIPTION
## Dominio
- `domain/entities.py` — entidades `Notification` y `AuditEntry`
- `domain/events.py` — eventos de dominio: `RequestCreated`, `RequestSubmitted`, `RequestApproved`, `RequestRejected`, `ReviewerAssigned`, `ChangesRequested`, `UserCreated`

## Application — Servicios y patrones
- `event_bus.py` — `EventBus` como **Singleton**; métodos `subscribe` y `publish`
- `notification_service.py` — `NotificationService` con patrón **Strategy**: `NotificationChannel` (Protocol), `InAppChannel` (persiste en DB) y `EmailChannel` (mock que loguea, activable con `EMAIL_NOTIFICATIONS=true`)
- `audit_service.py` — `AuditService` suscrito al bus; genera un `AuditEntry` por cada evento relevante
- Ambos servicios siguen el patrón **Observer**: se registran en el bus al arrancar la app

## Infraestructura
- `db/models.py` — `NotificationModel` y `AuditEntryModel` (tablas `notifications` y `audit_entries`)
- `notification_repository.py` — `save`, `list_for_user`, `mark_read`
- `audit_repository.py` — `save`, `list_all`, `list_for_entity`

## API
- `main.py` — lifespan con `@asynccontextmanager` (reemplaza `@on_event` deprecated); conecta repos, servicios y EventBus al arrancar
- `schemas.py` — `NotificationResponse`, `AuditEntryResponse`
- `dependencies.py` — `get_notification_repo`, `get_audit_repo`; corrección de imports rotos del módulo auth
- `routes/notifications.py` — `GET /notifications/me`, `POST /notifications/{id}/read`
- `routes/audit.py` — `GET /audit`, `GET /audit/{entity_type}/{entity_id}`

## Frontend
- `main.py` — badge en el sidebar con conteo de notificaciones no leídas
- `pages/notifications.py` — lista de notificaciones con estado leído/no leído y botón "Marcar leída"
- `pages/request_detail.py` — sección "Historial" con log de auditoría de la solicitud

## Tests
- `test_notifications_audit.py` — 15 tests unitarios con fakes en memoria: `NotificationService` (6), `AuditService` (6), `EventBus` (3)

## Fix incluido
- `domain/value_objects.py` — import roto `from domain.enums` → `from app.domain.enums` que bloqueaba el arranque del backend

---

closes #28
closes #29
closes #30
closes #31